### PR TITLE
v1.11.1 追加修正: MFM コンテンツの stripHtml 適用条件

### DIFF
--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -1441,7 +1441,9 @@ class _PostTileState extends ConsumerState<PostTile> {
           try {
             // Build new body: original body + new footer tags.
             final tagLine = tags.map((t) => '#$t').join(' ');
-            final bodyText = stripHtml(parsed.body).trimRight();
+            final bodyText =
+                (retagIsHtml ? stripHtml(parsed.body) : parsed.body)
+                    .trimRight();
             final newContent =
                 bodyText + (tagLine.isNotEmpty ? '\n\n$tagLine' : '');
 


### PR DESCRIPTION
## Summary

- MFM（非HTML）コンテンツに対して stripHtml を適用しないよう条件分岐を追加 (#268)
- PR #270 の Codex レビュー指摘への対応

## Test plan

- [x] Mastodon（HTML）投稿の「削除してタグづけ」が正常に動作すること
- [x] Misskey（MFM）投稿でアングルブラケットを含む内容が壊れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)