### PR TITLE
feat: #333 簡易入力バーに絵文字履歴パレットを追加

### DIFF
--- a/packages/capsicum/lib/src/provider/server_config_provider.dart
+++ b/packages/capsicum/lib/src/provider/server_config_provider.dart
@@ -122,6 +122,20 @@ final sabacanUrlProvider = FutureProvider<String?>((ref) async {
   }
 });
 
+/// 現在アカウントのサーバーが提供するカスタム絵文字一覧。アカウント切替で
+/// 自動再 fetch される。常時 mount される SimplePostBar 等から繰り返し参照
+/// される想定でキャッシュ目的に分離（emoji_picker は state 変数で都度 fetch
+/// しているが、別 issue でこちらに寄せる余地あり）。
+final customEmojisProvider = FutureProvider<List<CustomEmoji>>((ref) async {
+  final adapter = ref.watch(currentAdapterProvider);
+  if (adapter is! CustomEmojiSupport) return const [];
+  try {
+    return await (adapter as CustomEmojiSupport).getEmojis();
+  } catch (_) {
+    return const [];
+  }
+});
+
 /// Local timeline display name: use default hashtag if available.
 final localTimelineNameProvider = Provider<String>((ref) {
   final mulukhiya = ref.watch(currentMulukhiyaProvider);

--- a/packages/capsicum/lib/src/ui/widget/simple_post_bar.dart
+++ b/packages/capsicum/lib/src/ui/widget/simple_post_bar.dart
@@ -36,6 +36,7 @@ class SimplePostBar extends ConsumerStatefulWidget {
 class _SimplePostBarState extends ConsumerState<SimplePostBar> {
   final _controller = TextEditingController();
   bool _sending = false;
+  bool _paletteOpen = false;
 
   @override
   void dispose() {
@@ -116,10 +117,27 @@ class _SimplePostBarState extends ConsumerState<SimplePostBar> {
     }
   }
 
+  /// カーソル位置（または末尾）に絵文字エントリを挿入する。
+  /// recentEmojisProvider の add は LRU で先頭に持ち上がるため、再選択でも履歴
+  /// 順序がリフレッシュされる。
+  void _insertEmoji(String entry) {
+    final selection = _controller.selection;
+    final text = _controller.text;
+    final start = selection.start >= 0 ? selection.start : text.length;
+    final end = selection.end >= 0 ? selection.end : text.length;
+    _controller.value = TextEditingValue(
+      text: text.replaceRange(start, end, entry),
+      selection: TextSelection.collapsed(offset: start + entry.length),
+    );
+    ref.read(recentEmojisProvider.notifier).add(entry);
+  }
+
   @override
   Widget build(BuildContext context) {
     final postLabel = ref.watch(postLabelProvider);
     final colorScheme = Theme.of(context).colorScheme;
+    final recents = ref.watch(recentEmojisProvider);
+    final hasRecents = recents.isNotEmpty;
 
     return Container(
       decoration: BoxDecoration(
@@ -134,49 +152,117 @@ class _SimplePostBarState extends ConsumerState<SimplePostBar> {
         top: 8,
         bottom: MediaQuery.of(context).padding.bottom + 8,
       ),
-      child: Row(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: TextField(
-              controller: _controller,
-              enabled: !_sending,
-              textInputAction: TextInputAction.send,
-              onSubmitted: (_) => _submit(),
-              decoration: InputDecoration(
-                hintText: '$postLabel...',
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 10,
+          if (_paletteOpen && hasRecents) _buildPalette(recents),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  enabled: !_sending,
+                  textInputAction: TextInputAction.send,
+                  onSubmitted: (_) => _submit(),
+                  decoration: InputDecoration(
+                    hintText: '$postLabel...',
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 10,
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      borderSide: BorderSide.none,
+                    ),
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                  ),
                 ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(20),
-                  borderSide: BorderSide.none,
-                ),
-                filled: true,
-                fillColor: colorScheme.surfaceContainerHighest,
               ),
-            ),
-          ),
-          const SizedBox(width: 4),
-          IconButton(
-            icon: const Icon(Icons.open_in_new, size: 20),
-            tooltip: '詳細な$postLabel画面',
-            onPressed: _sending ? null : _openCompose,
-          ),
-          IconButton(
-            icon: _sending
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.send),
-            tooltip: postLabel,
-            onPressed: _sending ? null : _submit,
+              const SizedBox(width: 4),
+              if (hasRecents)
+                IconButton(
+                  icon: Icon(
+                    _paletteOpen
+                        ? Icons.keyboard_hide_outlined
+                        : Icons.emoji_emotions_outlined,
+                    size: 20,
+                  ),
+                  tooltip: _paletteOpen ? 'パレットを閉じる' : '絵文字履歴',
+                  onPressed: _sending
+                      ? null
+                      : () => setState(() => _paletteOpen = !_paletteOpen),
+                ),
+              IconButton(
+                icon: const Icon(Icons.open_in_new, size: 20),
+                tooltip: '詳細な$postLabel画面',
+                onPressed: _sending ? null : _openCompose,
+              ),
+              IconButton(
+                icon: _sending
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.send),
+                tooltip: postLabel,
+                onPressed: _sending ? null : _submit,
+              ),
+            ],
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildPalette(List<String> recents) {
+    final customEmojis =
+        ref.watch(customEmojisProvider).valueOrNull ?? const [];
+    final customByCode = {for (final e in customEmojis) e.shortcode: e};
+
+    return SizedBox(
+      height: 44,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: recents.length,
+        itemBuilder: (context, index) =>
+            _buildPaletteItem(recents[index], customByCode),
+      ),
+    );
+  }
+
+  Widget _buildPaletteItem(
+    String entry,
+    Map<String, CustomEmoji> customByCode,
+  ) {
+    final isCustom = entry.startsWith(':') && entry.endsWith(':');
+    Widget child;
+    if (isCustom) {
+      final shortcode = entry.substring(1, entry.length - 1);
+      final custom = customByCode[shortcode];
+      if (custom != null && custom.url.isNotEmpty) {
+        child = SizedBox(
+          width: 28,
+          height: 28,
+          child: Image.network(
+            custom.url,
+            fit: BoxFit.contain,
+            errorBuilder: (context, error, stack) =>
+                Text(entry, style: const TextStyle(fontSize: 12)),
+          ),
+        );
+      } else {
+        child = Text(entry, style: const TextStyle(fontSize: 12));
+      }
+    } else {
+      child = Text(entry, style: const TextStyle(fontSize: 24));
+    }
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => _insertEmoji(entry),
+      child: Padding(padding: const EdgeInsets.all(6), child: child),
     );
   }
 }


### PR DESCRIPTION
## Summary
- SimplePostBar に絵文字履歴の横スクロールパレットを追加。トグルボタンで開閉
- 既存の \`recentEmojisProvider\` (LRU 30 件) を流用。ユニコード/カスタム両対応
- カスタム絵文字の URL 解決用に \`customEmojisProvider\` (FutureProvider, host 単位キャッシュ) を新設
- タップでカーソル位置に絵文字エントリを挿入し、履歴順序もリフレッシュ
- 履歴が空のときはトグル自体を非表示

Fixes #333

## Test plan
- [x] dart analyze: No issues found
- [x] flutter test: 24 passed
- [x] 実機確認: pooza 確認済み

## スコープ外（別 issue 候補）
- emoji_picker の \`customEmojisProvider\` 移行
- パレット自動展開設定の永続化

🤖 Generated with [Claude Code](https://claude.com/claude-code)