### PR TITLE
fix: #385 / #386 — Keychain accessibility と lastTab sync fallback の修正

### DIFF
--- a/packages/capsicum/lib/src/service/push_key_store.dart
+++ b/packages/capsicum/lib/src/service/push_key_store.dart
@@ -22,9 +22,17 @@ class PushKeyStore {
   /// entitlements に解決できず、書き込み・読み出しが silent に失敗する。
   /// `Y27AK8VF85` は Xcode project の `DEVELOPMENT_TEAM` と一致 (#373 候補 B)。
   /// NSE 側 [PushKeyReader.accessGroup] と同じ文字列を使うこと。
+  ///
+  /// [KeychainAccessibility.first_unlock]（= `kSecAttrAccessibleAfterFirstUnlock`）
+  /// は再起動後の最初のアンロック以降であればロック中でも read/write 可能にする。
+  /// 既定の `unlocked` だとバックグラウンド経路（NSE / トークン更新 / 通知到着等）が
+  /// デバイスロック中に -25308 errSecInteractionNotAllowed で弾かれる (#385)。
   static const _iOSAccessGroup = 'Y27AK8VF85.group.jp.co.b-shock.capsicum';
   static const _storage = FlutterSecureStorage(
-    iOptions: IOSOptions(groupId: _iOSAccessGroup),
+    iOptions: IOSOptions(
+      groupId: _iOSAccessGroup,
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
   );
   static const _prefix = 'capsicum_push_';
 

--- a/packages/capsicum/lib/src/ui/screen/home_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/home_screen.dart
@@ -214,10 +214,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           }
         });
         // Also check synchronously in case the value was already loaded.
+        // build 中に selectedTabProvider を書き換えると Riverpod の
+        // `_debugCanModifyProviders` assertion で例外になるため、
+        // d08897c (#281 latent fix) と同じく postFrame に延期する (#386)。
         final saved = ref.read(lastTabProvider(storageKey));
         if (!_lastTabRestored && saved != null) {
           _lastTabRestored = true;
-          _applyLastTab(saved);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _applyLastTab(saved);
+          });
         }
       }
     }


### PR DESCRIPTION
v1.20.2 ホットフィックス候補だった 2 件を v1.21 に組み込むための PR。リスク評価の結果ホットフィックスは見送り、通常の develop 経路で次リリースに含める。

## #385 — PushKeyStore Keychain accessibility

iOS でデバイスロック中の Keychain write が `PlatformException(-25308 errSecInteractionNotAllowed)` で弾かれていた問題。

- `IOSOptions(accessibility: KeychainAccessibility.first_unlock)` を指定して、再起動後の最初のアンロック以降であればロック中でも read/write 可能に
- NSE 側 (PushKeyReader.swift) は変更不要（accessibility は item 側で決まる）
- 副次的に #366 / #376 で観測されている nse.decrypt_failed の一部解消も期待

## #386 — lastTab sync fallback path postFrame 延期

`HomeScreen` の build 中に `selectedTabProvider.notifier.state = ...` を呼んでおり、Riverpod の `_debugCanModifyProviders` assertion で「Tried to modify a provider while the widget tree was building」例外が発火していた問題。

- d08897c (#281 latent fix) で同 assertion の別経路は postFrame に延期済みだったが、sync fallback path は見落とし
- `WidgetsBinding.instance.addPostFrameCallback` でラップ
- 挙動（sync で既に lastTab が読めていた場合の復元）は同一

## 検証

検証ビルド (1.20.2+49) で iOS / Android 両方タイムライン表示まで確認済み。次の v1.21 ビルドで再確認する。

## 関連

- v1.20.2 マイルストーンは close（このリリースは行わない）
- 両 issue は v1.21 マイルストーンへ移動

Closes #385
Closes #386