### PR TITLE
feat: #407 macOS fastlane レーンと .pkg ラップ手順を整備

### DIFF
--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -38,7 +38,7 @@ flowchart TB
     subgraph fastlane [fastlane レーン]
         ios_lane[iOS: upload_to_testflight / app_store]
         and_lane[Android: upload_to_play_store]
-        mac_lane[macOS: deliver + notarize + create-dmg]
+        mac_lane[macOS: upload_to_testflight / app_store]
     end
 
     actions -->|macOS runner| fastlane
@@ -48,7 +48,7 @@ flowchart TB
 
     ios_lane --> appstore[App Store / TestFlight]
     and_lane --> playstore[Google Play]
-    mac_lane --> macstore[Mac App Store / .dmg 配布]
+    mac_lane --> macstore[Mac App Store]
     win --> msstore[Microsoft Store]
     flat --> flathub[Flathub]
     appimg --> ghrel[GitHub Releases]
@@ -60,13 +60,22 @@ flowchart TB
 | --- | --- | --- | --- |
 | iOS | fastlane (`ios/fastlane/Fastfile`) | macOS runner | TestFlight → App Store |
 | Android | fastlane (`android/fastlane/Fastfile`) | macOS / Linux runner | Play Store internal → production |
-| macOS (App Store) | fastlane `deliver` + `notarize` | macOS runner | Mac App Store |
-| macOS (.dmg) | fastlane `create-dmg` + `notarize` + Sparkle 等 | macOS runner | GitHub Releases / 自サイト配布 |
+| macOS | fastlane (`macos/fastlane/Fastfile`) | macOS runner | TestFlight → Mac App Store |
 | Windows (Store) | `msstore` CLI + MSIX packaging | Windows runner | Microsoft Store |
 | Linux (Flathub) | `flatpak-builder` + Flathub マニフェスト PR | Ubuntu runner | Flathub |
 | Linux (AppImage) | `appimagetool` / `linuxdeploy` | Ubuntu runner | GitHub Releases |
 
 Snap Store は[採用しない方針](CLAUDE.md#長期構想-デスクトップ対応)。
+
+### macOS は Mac App Store 一本化
+
+macOS の配布は **Mac App Store のみ**とする（.dmg / Developer ID 配布は採用しない）。理由:
+
+- macOS のセキュリティ設定で「App Store からのアプリのみ許可」にしているユーザーには、公証済みでも App Store 外のバイナリは実行できない
+- 配布経路を二系統にすると署名・公証・更新通知（Sparkle 等）の運用コストが二重になる
+- iOS と同一 App レコードに Universal Purchase で紐付け済みのため、ストア一本化が素直
+
+このため fastlane レーンは `upload_to_testflight` / `upload_to_app_store` のみで、`create-dmg` / `notarize` は使わない。`.pkg` の生成手順は [store-release-guide.md](store-release-guide.md) 4.2 を参照。
 
 ## タグ命名規則
 
@@ -129,8 +138,8 @@ macOS 署名・公証用の証明書は Actions の `apple-actions/import-codesi
 
 ### Phase 3: macOS ネイティブ対応（デスクトップ第1段階）
 
-- macOS デスクトップビルドの fastlane レーン追加
-- `deliver` + `notarize` + `create-dmg` の組み合わせで Mac App Store / .dmg 両対応
+- macOS デスクトップビルドの fastlane レーン追加（`upload_to_testflight` / `upload_to_app_store` で Mac App Store 提出のみ）
+- `flutter build macos --release` → `xcodebuild archive` → `-exportArchive` で `.pkg` を生成し、Universal Purchase 済みの App レコードに `platform: 'osx'` で投げる
 - Phase 2 の GitHub Actions に macOS ネイティブ分岐を追加
 
 ### Phase 4: Windows / Linux 対応（デスクトップ第3段階）

--- a/docs/store-release-guide.md
+++ b/docs/store-release-guide.md
@@ -33,14 +33,16 @@
 
 ### 1.4 macOS 署名 / Universal Purchase（v1.21 で初回セットアップ）
 
-macOS ネイティブビルドは iOS と同じ Bundle ID `jp.co.b-shock.capsicum` を Universal Purchase で紐付け、AppStore Connect 上は同一 App レコードで管理する方針。
+macOS ネイティブビルドは iOS と同じ Bundle ID `jp.co.b-shock.capsicum` を Universal Purchase で紐付け、AppStore Connect 上は同一 App レコードで管理する方針。配布は **Mac App Store 一本**（.dmg / Developer ID 配布は採用しない — [release-pipeline.md](release-pipeline.md) 参照）。
 
 - [ ] Apple Developer ポータルで **macOS App ID** を新規作成
   - Bundle ID: `jp.co.b-shock.capsicum`（iOS と同一文字列。プラットフォームが違うため衝突しない）
   - Capabilities: **App Sandbox**（Release entitlements で必須）／ **Push Notifications**（capsicum-relay 経由で利用）
 - [ ] AppStore Connect の既存 iOS app `capsicum` レコードで **「Add Mac App Version」** を実行し、上記 macOS App ID と紐付け（Universal Purchase 化）
   - ⚠️ Universal Purchase の紐付けは **後から外せない**。Bundle ID と App 名はこの時点で確定させる
-- [ ] **macOS App Development Profile** と **macOS App Distribution Profile** を作成 — Automatic Signing で自動管理
+- [ ] **macOS App Development Profile** と **Mac App Store Provisioning Profile** を作成 — Automatic Signing で自動管理
+- [ ] **3rd Party Mac Developer Installer** 証明書を Apple Developer ポータルから取得し、ビルドマシンの Keychain に登録
+  - `.pkg` の installer 署名に必須。Apple Distribution（アプリ署名）とは別証明書で、Xcode の Automatic 管理対象外のため手動で配置する
 - [ ] Xcode で `packages/capsicum/macos/Runner.xcodeproj` を開き、Runner / RunnerTests ターゲットの `DEVELOPMENT_TEAM` を `Y27AK8VF85` に設定（iOS と同一 Team）
 - [ ] Mac App Store 用スクリーンショット（1280×800 / 1440×900 / 2560×1600 のいずれか）を用意
 
@@ -153,7 +155,36 @@ end
 ```
 
 > **Fastlane の実行ディレクトリ:**
-> `fastlane beta` / `fastlane internal` / `fastlane release` は **必ず** `packages/capsicum/ios/` または `packages/capsicum/android/` の Fastfile があるディレクトリから実行する。リポジトリルートや別ディレクトリから実行すると ipa / aab の相対パスが解決できず「Could not find ipa/aab file」エラーになり、アップロードが失敗する。v1.11.0 リリース時にこの問題で全アップロードがやり直しになった経緯がある。
+> `fastlane beta` / `fastlane internal` / `fastlane release` は **必ず** `packages/capsicum/ios/`、`packages/capsicum/android/`、`packages/capsicum/macos/` のいずれか、Fastfile があるディレクトリから実行する。リポジトリルートや別ディレクトリから実行すると ipa / aab / pkg の相対パスが解決できず「Could not find ipa/aab/pkg file」エラーになり、アップロードが失敗する。v1.11.0 リリース時にこの問題で全アップロードがやり直しになった経緯がある。
+
+### 3.4 macOS（`macos/fastlane/Fastfile`）
+
+ビルドは事前に行い、Fastlane は TestFlight / Mac App Store への `.pkg` アップロードのみを担当する。`.pkg` の生成手順は 4.2 を参照。
+
+```ruby
+default_platform(:mac)
+
+platform :mac do
+  desc "Deploy to TestFlight"
+  lane :beta do
+    upload_to_testflight(
+      pkg: '../build/macos/capsicum.pkg',
+    )
+  end
+
+  desc "Submit to Mac App Store"
+  lane :release do
+    upload_to_app_store(
+      pkg: '../build/macos/capsicum.pkg',
+      platform: 'osx',
+      submit_for_review: true,
+    )
+  end
+end
+```
+
+> **`platform: 'osx'` が必須:**
+> `upload_to_app_store` は既定で iOS の App レコードを対象にする。Universal Purchase で同一 App レコード上に macOS バージョンが乗っているため、`platform: 'osx'` を明示しないと iOS 側の最新ビルドに対する審査提出として解釈され、誤った提出になる。
 
 ## 4. リリース手順（毎回）
 
@@ -240,7 +271,32 @@ flutter build appbundle --release \
 cd android
 fastlane internal
 cd ..
+
+# macOS: flutter build → xcodebuild archive → exportArchive で .pkg 生成 → TestFlight アップロード
+# `flutter build macos` 単体では Apple Development 署名 + Mac App Development profile が
+# 埋め込まれるだけで App Store 提出には使えない。Generated.xcconfig に DART_DEFINES を反映
+# させたうえで xcodebuild archive 経由で Apple Distribution + Mac App Store profile に切り替える。
+flutter build macos --release \
+  --dart-define=SENTRY_DSN=$SENTRY_DSN \
+  --dart-define=SENTRY_ENV=production \
+  --dart-define=RELAY_SECRET=$RELAY_SECRET
+xcodebuild -workspace macos/Runner.xcworkspace \
+  -scheme Runner \
+  -configuration Release \
+  -archivePath build/macos/capsicum.xcarchive \
+  archive
+xcodebuild -exportArchive \
+  -archivePath build/macos/capsicum.xcarchive \
+  -exportOptionsPlist macos/ExportOptions.plist \
+  -exportPath build/macos
+# build/macos/capsicum.pkg が生成される
+cd macos
+fastlane beta
+cd ..
 ```
+
+> **macOS の `.pkg` 生成が iOS と異なる理由:**
+> iOS は `flutter build ipa --release` 一発で App Store 提出可能な ipa が出来るが、macOS の `flutter build macos --release` は Apple Development 証明書 + Mac App Development profile を埋め込んだ `.app` を出力するだけで、Mac App Store には提出できない。`xcodebuild archive` + `-exportArchive` を経由することで Apple Distribution + Mac App Store profile + 3rd Party Mac Developer Installer による `.pkg` 署名が automatic に行われる。`flutter build macos` を先に走らせるのは Generated.xcconfig の `DART_DEFINES` を更新するため（archive 単独では `--dart-define` を渡せない）。
 
 ### 4.3 製品版昇格・審査提出
 
@@ -252,6 +308,9 @@ cd android && fastlane release && cd ..
 
 # iOS: App Store 審査提出
 cd ios && fastlane release && cd ..
+
+# macOS: Mac App Store 審査提出
+cd macos && fastlane release && cd ..
 ```
 
 審査提出時のリリースノート（「このバージョンの新機能」欄）には、そのバージョンの変更内容の要約を記載すること。
@@ -270,6 +329,7 @@ gh issue list --label bug --state open
 
 - **iOS**: TestFlight 外部テスター経由（内部テスターは本名相互公開の問題があるため不使用）
 - **Android**: Google Play で直接配布（GitHub Releases への APK 添付は v1.5.1 で廃止）
+- **macOS**: Mac App Store 一本（.dmg / Developer ID 配布は採用しない）。「App Store からのアプリのみ許可」設定のユーザーに届かない問題と、署名・公証・更新通知の二重メンテを避けるため。詳細は [release-pipeline.md](release-pipeline.md) 参照
 - **Google Play アカウント**: 法人（Google Workspace）アカウントのため、クローズドテスト 12 人要件は免除
 - **ホットフィックス**: Fastfile の構成上 internal → promote の手順が必要（production に直接アップロードは不可）
 - **App Store の説明文更新**: リリース提出時のみ可能。随時更新はできない

--- a/docs/store-release-guide.md
+++ b/docs/store-release-guide.md
@@ -284,11 +284,13 @@ xcodebuild -workspace macos/Runner.xcworkspace \
   -scheme Runner \
   -configuration Release \
   -archivePath build/macos/capsicum.xcarchive \
+  -allowProvisioningUpdates \
   archive
 xcodebuild -exportArchive \
   -archivePath build/macos/capsicum.xcarchive \
   -exportOptionsPlist macos/ExportOptions.plist \
-  -exportPath build/macos
+  -exportPath build/macos \
+  -allowProvisioningUpdates
 # build/macos/capsicum.pkg が生成される
 cd macos
 fastlane beta

--- a/packages/capsicum/macos/ExportOptions.plist
+++ b/packages/capsicum/macos/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store</string>
+	<key>destination</key>
+	<string>export</string>
+	<key>teamID</key>
+	<string>Y27AK8VF85</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+</dict>
+</plist>

--- a/packages/capsicum/macos/ExportOptions.plist
+++ b/packages/capsicum/macos/ExportOptions.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>method</key>
-	<string>app-store</string>
+	<string>app-store-connect</string>
 	<key>destination</key>
 	<string>export</string>
 	<key>teamID</key>

--- a/packages/capsicum/macos/Runner/Info.plist
+++ b/packages/capsicum/macos/Runner/Info.plist
@@ -16,6 +16,8 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.social-networking</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>

--- a/packages/capsicum/macos/Runner/Info.plist
+++ b/packages/capsicum/macos/Runner/Info.plist
@@ -18,6 +18,8 @@
 	<string>APPL</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.social-networking</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>

--- a/packages/capsicum/macos/fastlane/Fastfile
+++ b/packages/capsicum/macos/fastlane/Fastfile
@@ -1,0 +1,34 @@
+default_platform(:mac)
+
+platform :mac do
+  desc "Deploy to TestFlight"
+  lane :beta do
+    api_key = app_store_connect_api_key(
+      key_id: 'WLS8G4W44L',
+      issuer_id: '69a6de71-e621-47e3-e053-5b8c7c11a4d1',
+      key_filepath: File.expand_path('~/.config/capsicum/AuthKey_WLS8G4W44L.p8'),
+    )
+    upload_to_testflight(
+      pkg: '../build/macos/capsicum.pkg',
+      api_key: api_key,
+    )
+  end
+
+  desc "Submit to Mac App Store"
+  lane :release do
+    api_key = app_store_connect_api_key(
+      key_id: 'WLS8G4W44L',
+      issuer_id: '69a6de71-e621-47e3-e053-5b8c7c11a4d1',
+      key_filepath: File.expand_path('~/.config/capsicum/AuthKey_WLS8G4W44L.p8'),
+    )
+    upload_to_app_store(
+      pkg: '../build/macos/capsicum.pkg',
+      api_key: api_key,
+      platform: 'osx',
+      submit_for_review: true,
+      force: true,
+      skip_binary_upload: true,
+      precheck_include_in_app_purchases: false,
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- `packages/capsicum/macos/fastlane/Fastfile` を新規作成。`upload_to_testflight` / `upload_to_app_store` で TestFlight → Mac App Store 提出を担う。`upload_to_app_store` には `platform: 'osx'` を明示（Universal Purchase 共有 App レコードで iOS と区別するため必須）
- `packages/capsicum/macos/ExportOptions.plist` を新規作成。`xcodebuild -exportArchive` 経由で Apple Distribution + Mac App Store profile + 3rd Party Mac Developer Installer 署名による `.pkg` を automatic に生成する設定
- `docs/store-release-guide.md` の 1.4 / 3.4 / 4.2 / 4.3 / 5 に macOS 手順を追記。`flutter build macos --release` 単体は Apple Development 署名 + Mac App Development profile が埋め込まれるだけで App Store 提出に使えないため、`flutter build macos` で `Generated.xcconfig` の `DART_DEFINES` を更新したうえで `xcodebuild archive` + `-exportArchive` を経由する流れを明記
- `docs/release-pipeline.md` で macOS 配布を **Mac App Store 一本化**（.dmg / Developer ID 配布は採用しない）と明記。「App Store からのアプリのみ許可」設定のユーザーに公証済みでも届かない問題と、署名・公証・更新通知の二重メンテを避けるため

## Test plan

- [ ] 1.4 の事前作業（macOS App ID / Universal Purchase 紐付け / Mac App Store Provisioning Profile / 3rd Party Mac Developer Installer 証明書取得）が完了していることを確認
- [ ] `flutter build macos --release --dart-define=...` 実行
- [ ] `xcodebuild archive` で `build/macos/capsicum.xcarchive` が生成されることを確認
- [ ] `xcodebuild -exportArchive` で `build/macos/capsicum.pkg` が生成され、Apple Distribution + Mac App Store profile で署名されていることを `codesign -dvv` / `pkgutil --check-signature` で確認
- [ ] `cd macos && fastlane beta` で TestFlight に `.pkg` がアップロードされることを確認
- [ ] TestFlight 配信後、Mac で実行できることを確認
- [ ] `cd macos && fastlane release` で Mac App Store 審査提出（`platform: 'osx'` で正しく macOS バージョン側に提出されることを確認）

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)