### PR TITLE
docs: デスクトップ第3段階から video_player → media_kit 必須移行を外す

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -272,7 +272,7 @@ macOS / Linux / Windows のデスクトップ環境への展開。動機は、iO
 
 1. **第1段階: macOS ネイティブ化（v1.21、土台完成）** — `flutter config --enable-macos-desktop` を有効化し、Apple Developer Team / Apple Development 署名 / App Sandbox / Hardened Runtime / keychain-access-groups の設定を導入。Universal Purchase で iOS と同一 App レコードに紐付け済み。プラグインのデスクトップ対応状況の棚卸し・video_player → media_kit の事前調査もこの段階で完了。ストア配布（.pkg ラップ + fastlane の macOS lane）は [#407](https://github.com/pooza/capsicum/issues/407) で v1.21.x にて対応する
 2. **第2段階: バックグラウンド/通知モデルの再設計（v1.23）** — デスクトップにはバックグラウンド更新の概念がないため、通知ポーリング相当の仕組みを抽象化して差し替え可能にする。v1.18 のプッシュ通知リレー完了・v1.19 (#348) での workmanager / iOS BGTask 撤去後、モバイル側は APNs / FCM 一本化済み。デスクトップ向けには Dart `Timer` + 常駐前提のフォールバック実装を含む `BackgroundTaskScheduler` 層と、`flutter_local_notifications` のデスクトップ対応差分を吸収する層が要る
-3. **第3段階: Linux / Windows 対応（v1.24）** — 第2段階で通知周りが整理され、プラグイン依存の棚卸しが済んでから本格着手。配布形態（Linux: Flathub + AppImage、Windows: Microsoft Store）もこの段階で決める。Linux と Windows のどちらを先にやるかは未定。v1.21 で事前調査した video_player → media_kit の本移行もこの段階
+3. **第3段階: Linux / Windows 対応（v1.24）** — 第2段階で通知周りが整理され、プラグイン依存の棚卸しが済んでから本格着手。配布形態（Linux: Flathub + AppImage、Windows: Microsoft Store）もこの段階で決める。Linux と Windows のどちらを先にやるかは未定。video_player → media_kit の本移行は v1.21 の TestFlight Internal 検証で video_player が macOS 上で再生・添付・投稿とも問題なく動作することが確認できた（pooza が動画つき投稿で意図的に検証）ため緊急性が下がっており、第3段階の必須スコープからは外す。Linux / Windows 着手時に各プラットフォームの video_player 対応状況を改めて棚卸しし、必要があれば移行を判断する位置付けにする
 
 第1段階と第2段階のあいだに **v1.22: Misskey メッセージ機能対応** を単独配置する（大更新を他の大更新と並走させない方針）。
 


### PR DESCRIPTION
## Summary

v1.21 の macOS TestFlight Internal 検証で、video_player が macOS 上で **再生・添付・投稿** いずれも問題なく動作することが確認できた（pooza が動画つき投稿で意図的に検証: https://mstdn.b-shock.org/@pooza/116484630526026906 ）。

これにより、当初 v1.24（Linux / Windows 対応）の必須スコープに含めていた media_kit への本移行は緊急性が下がった。第3段階の説明を「video_player → media_kit の本移行もこの段階」から「Linux / Windows 着手時に各プラットフォームの video_player 対応状況を改めて棚卸しし、必要があれば移行を判断する位置付け」に緩める。

## Test plan

- [ ] CLAUDE.md のデスクトップ対応 第3段階の文面を読み返し、現状認識と齟齬がないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)