### PR TITLE
1.23.1: macOS App Store リジェクト hotfix

### DIFF
--- a/packages/capsicum/lib/src/service/push_key_store.dart
+++ b/packages/capsicum/lib/src/service/push_key_store.dart
@@ -11,9 +11,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 鍵はアカウントごとに生成・保存され、リレーサーバー経由で受信した
 /// Web Push ペイロードの復号に使用する（復号の実装は Stage 2）。
 class PushKeyStore {
-  /// iOS では Notification Service Extension (#336 Phase 3(b)) が復号に
-  /// 使うため、Keychain を Runner / NSE 共通の Access Group に逃がす。
-  /// Android の [AndroidOptions] は EncryptedSharedPreferences 既定で十分で、
+  /// iOS の Notification Service Extension (#336 Phase 3(b)) と macOS の
+  /// バックグラウンド経路で復号に使うため、Keychain を Runner / NSE 共通の
+  /// Access Group に逃がす。macOS 側 entitlement (#397) と一致させる必要が
+  /// あり、IOSOptions と MacOsOptions に同じ値を指定する。Android の
+  /// [AndroidOptions] は EncryptedSharedPreferences 既定で十分で、
   /// バックグラウンド isolate も同一プロセス内のため追加設定は不要。
   ///
   /// `kSecAttrAccessGroup` は **TeamID + ドット + グループ名** の完全表記が
@@ -28,10 +30,14 @@ class PushKeyStore {
   /// は再起動後の最初のアンロック以降であればロック中でも read/write 可能にする。
   /// 既定の `unlocked` だとバックグラウンド経路（NSE / トークン更新 / 通知到着等）が
   /// デバイスロック中に -25308 errSecInteractionNotAllowed で弾かれる (#385)。
-  static const _iOSAccessGroup = 'Y27AK8VF85.group.jp.co.b-shock.capsicum';
+  static const _appleAccessGroup = 'Y27AK8VF85.group.jp.co.b-shock.capsicum';
   static const _storage = FlutterSecureStorage(
     iOptions: IOSOptions(
-      groupId: _iOSAccessGroup,
+      groupId: _appleAccessGroup,
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
+    mOptions: MacOsOptions(
+      groupId: _appleAccessGroup,
       accessibility: KeychainAccessibility.first_unlock,
     ),
   );

--- a/packages/capsicum/lib/src/service/push_registration_service.dart
+++ b/packages/capsicum/lib/src/service/push_registration_service.dart
@@ -81,6 +81,14 @@ class PushRegistrationService {
     // 必要がある（wipe すると古いサーバー側サブスクリプションが orphan 化）。
     var localStateModified = false;
     try {
+      // 本配線が無いプラットフォームでは試行自体を止め、UI 上は「対象外」
+      // として整合させる（#467: macOS）。registerAllAccounts 側でも guard
+      // しているが、tokenRefresh など別経路から呼ばれる場合の保険として
+      // ここでも止める。
+      if (Platform.isMacOS) {
+        store.update(accountKey, PushRegistrationState.skipped);
+        return;
+      }
       if (account.adapter is! PushSubscriptionSupport) {
         store.update(accountKey, PushRegistrationState.skipped);
         return;
@@ -430,6 +438,17 @@ class PushRegistrationService {
   /// デバイストークンが未取得の場合は到着を待ってから登録する。
   static Future<void> registerAllAccounts(List<Account> accounts) async {
     if (accounts.isEmpty) return;
+
+    // 本配線が無いプラットフォームでは _waitForDeviceToken (最大 10 秒) を
+    // 走らせず、各アカウントを「対象外」状態に揃えて即時 return する
+    // （#467: macOS）。
+    if (Platform.isMacOS) {
+      final store = PushRegistrationStatusStore.instance;
+      for (final account in accounts) {
+        store.update(account.key.toStorageKey(), PushRegistrationState.skipped);
+      }
+      return;
+    }
 
     // デバイストークンが未取得なら到着を待つ（最大 10 秒）
     if (_getDeviceToken() == null) {

--- a/packages/capsicum/lib/src/ui/screen/settings_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -41,13 +43,16 @@ class SettingsScreen extends ConsumerWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.push('/settings/display'),
           ),
-          ListTile(
-            leading: const Icon(Icons.notifications_outlined),
-            title: const Text('プッシュ通知'),
-            subtitle: const Text('アカウント別の登録状況・再試行'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.push('/settings/push'),
-          ),
+          // macOS は push 通知を本配線していない (#467)。本配線が入るまで
+          // 設定エントリも隠す。
+          if (!Platform.isMacOS)
+            ListTile(
+              leading: const Icon(Icons.notifications_outlined),
+              title: const Text('プッシュ通知'),
+              subtitle: const Text('アカウント別の登録状況・再試行'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/settings/push'),
+            ),
         ],
       ),
     );

--- a/packages/capsicum/lib/src/ui/widget/push_registration_status_section.dart
+++ b/packages/capsicum/lib/src/ui/widget/push_registration_status_section.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -86,6 +88,10 @@ class PushRegistrationStatusSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 本配線が無いプラットフォームでは UI ごと隠す（#467: macOS）。
+    // 表示しても登録は必ず token 取得失敗となり、ユーザーが再試行を繰り返す
+    // 混乱状態になるため、本配線が入るまでの暫定対応。
+    if (Platform.isMacOS) return const SizedBox.shrink();
     final account = ref.watch(currentAccountProvider);
     if (account == null) {
       return const Padding(

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.23.0+55
+version: 1.23.1+61
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
App Store v1.23.0+55 macOS 審査リジェクト (Guideline 2.1(a)) の対応。

## 含まれる修正

- #454 macOS Keychain Access Group を `MacOsOptions(groupId:)` で明示
- #467 macOS で push 登録 UI を隠す（再試行ループ予防）

## リジェクト内容

> Bug description: We received the attached action wheel indefinitely after logging in.

OAuth 完了後の access token 書き込みが Distribution 署名 + App Sandbox + entitlement (`group.jp.co.b-shock.capsicum`) と `flutter_secure_storage` の groupId 未指定の組み合わせで `errSecMissingEntitlement` (-34018) で silent fail し、ログイン状態が確定せずスピナーが回り続けていた、という診断。