### PR TITLE
docs: Linux 配布物の検証起動手順を追記

### DIFF
--- a/docs/store-release-guide.md
+++ b/docs/store-release-guide.md
@@ -374,7 +374,7 @@ bash packaging/linux/appimage/build.sh    # AppImage
 bash packaging/linux/flathub/build.sh     # Flatpak (要 GNOME Platform 49)
 ```
 
-詳細は各 README 参照。
+ビルド + 起動の詳細・配布物（GitHub Releases から DL した AppImage）の検証手順は [packaging/linux/appimage/README.md](../packaging/linux/appimage/README.md) §動作確認、Flatpak は [packaging/linux/flathub/README.md](../packaging/linux/flathub/README.md) を参照。
 
 ## 5. 配布方針
 

--- a/packaging/linux/appimage/README.md
+++ b/packaging/linux/appimage/README.md
@@ -75,11 +75,32 @@ bash packaging/linux/appimage/build.sh
 
 ## 動作確認
 
+### ローカルビルドの起動
+
+build.sh が出力する AppImage は実行ビット付き。そのまま起動可能。
+
 ```sh
 ./build/linux/dist/capsicum-1.24.0-x86_64.AppImage
 ```
 
-確認項目は #425 (実機検証 Issue) を参照。
+### 配布物 (GitHub Releases から DL した AppImage) の検証
+
+リリース直前 / 直後に、Linux 補助機で配布バイナリを実機検証する場合の手順。`linux-release.yml` がタグ駆動で生成して draft Release に添付した AppImage を、pooza が GitHub UI からダウンロード後:
+
+```sh
+chmod +x ~/Downloads/capsicum-1.24.0-x86_64.AppImage
+~/Downloads/capsicum-1.24.0-x86_64.AppImage
+```
+
+公開済み Release のアセットは curl からも取得可能 (draft 中は pooza のみアクセス可):
+
+```sh
+curl -LO https://github.com/pooza/capsicum/releases/download/v1.24.0/capsicum-1.24.0-x86_64.AppImage
+chmod +x capsicum-1.24.0-x86_64.AppImage
+./capsicum-1.24.0-x86_64.AppImage
+```
+
+確認項目は [#425](https://github.com/pooza/capsicum/issues/425) (Linux 実機検証 Issue) を参照。
 
 ## 制約
 


### PR DESCRIPTION
## Summary

- [#425](https://github.com/pooza/capsicum/issues/425) Linux 実機検証の前準備として、GitHub Releases に添付された AppImage を pooza さんが手元の Linux 補助機で検証するときの手順を明示
- 従来 [packaging/linux/appimage/README.md](packaging/linux/appimage/README.md) の「動作確認」はローカルビルドの起動だけを書いていたため、配布物検証時の `chmod +x` や `curl` 経由の DL 経路が想像しづらかった

## 更新内容

- `packaging/linux/appimage/README.md`: 「動作確認」を「ローカルビルドの起動」と「配布物 (GitHub Releases から DL した AppImage) の検証」の 2 サブセクションに分割
  - 配布物検証は GitHub UI 経由 DL の `chmod +x` 起動と curl 経由の DL 起動の両方を併記
- `docs/store-release-guide.md` §4.5「ローカル動作確認」: AppImage / Flatpak それぞれの詳細手順 README へのリンクを追加。リリース手順を辿る pooza さんが配布物検証手順に確実に到達できるようにする

挙動への影響なし。

## 関連

- [#425](https://github.com/pooza/capsicum/issues/425) Linux 実機検証
- [#424](https://github.com/pooza/capsicum/issues/424) Linux 配布パイプライン整備（実装済み）

## Test plan

- [ ] レンダリング確認: 該当箇所が GitHub UI で意図通り表示される
- [ ] CI: docs のみの変更で挙動影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)