### PR TITLE
release: v1.24.2 (Linux AppImage hotfix 2 — #532 真因対応)

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -36,12 +36,20 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # ibus-gtk3 を入れる理由 (#532 真因対応 / v1.24.2):
+          # GTK の ibus IM モジュール (im-ibus.so) は host にインストール
+          # されていないと linuxdeploy-plugin-gtk が AppImage に bundle で
+          # きない。CI runner (ubuntu-22.04) には標準で入っていないため、
+          # 配布 AppImage の immodules.cache から ibus エントリが欠落し、
+          # GTK_IM_MODULE=ibus を立てても解決できず日本語入力が一切
+          # 効かない状態だった。
           sudo apt-get update
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config \
             libgtk-3-dev libsecret-1-dev libwebkit2gtk-4.1-dev \
             libcurl4-openssl-dev default-jdk-headless \
-            libfuse2 patchelf
+            libfuse2 patchelf \
+            ibus-gtk3
 
       - name: Install linuxdeploy / appimagetool (with sha256 pin)
         # continuous / master という rolling アップデート tag から DL するが、

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.24.1+66
+version: 1.24.2+67
 
 environment:
   sdk: ^3.11.0

--- a/packaging/linux/appimage/build.sh
+++ b/packaging/linux/appimage/build.sh
@@ -138,16 +138,29 @@ linuxdeploy \
   --desktop-file "$APPDIR/usr/share/applications/$APP_ID.desktop" \
   --icon-file "$APPDIR/$APP_ID.png"
 
-# bundled libibus を除去する (#532)。linuxdeploy-plugin-gtk が ldd 経由で
-# libibus-1.0.so.5 を $APPDIR/usr/lib/ に同梱するが、これがホスト
-# ibus-daemon との DBus protocol drift を起こし、AppImage 配布版で日本語
-# IME (ibus-mozc 等) が一切効かなくなる現象が出る。bundled im-ibus.so は
-# 残し、libibus は ld.so の既定パス検索でホスト側を引かせる (im-ibus の
-# DT_NEEDED は libibus-1.0.so.5。RUNPATH/RPATH に AppDir が無くても、
-# ホストの /lib/x86_64-linux-gnu/libibus-1.0.so.5 が ld.so.cache 経由で
-# 見つかる)。Flatpak (org.gnome.Platform 提供 GTK + libibus) では発生
-# しないことから、bundle 経路だけの問題と確定済み。
-echo "==> Removing bundled libibus to avoid #532 (AppImage IME broken)"
+# bundled libibus を除去する (#532)。
+#
+# 経緯 (v1.24.1 → v1.24.2 訂正):
+# v1.24.1 リリース時は「linuxdeploy-plugin-gtk が ldd 経由で libibus-1.0.so.5
+# をバンドルしホスト ibus-daemon との DBus protocol drift を起こしている」
+# という仮説で本 rm を追加した。しかし真因は別で、CI runner (ubuntu-22.04)
+# に ibus-gtk3 がインストールされておらず im-ibus.so 自体が host に存在せず
+# AppImage に bundle されていない、つまり ibus 経路が完全に欠落していたこと
+# だった。v1.24.2 で workflow に ibus-gtk3 を追加して im-ibus.so が bundle
+# されるようにした結果、im-ibus.so / libibus-1.0.so.5 がどちらも bundle される
+# 状態になる。
+#
+# その上で libibus 本体は AppDir から除去し、ホスト側 libibus
+# (/lib/x86_64-linux-gnu/libibus-1.0.so.5) を ld.so.cache 経由で引かせる。
+# im-ibus.so の DT_NEEDED は libibus-1.0.so.5 で、RUNPATH/RPATH に AppDir が
+# 無くても解決される。host ibus-daemon と libibus の version を必ず一致させる
+# ことで protocol drift リスクを最小化する (Flatpak が同じ方針 = runtime 提供
+# の libibus + ibus-daemon 揃え、で問題なく動いている)。
+#
+# pooza の手元 (Debian 13 + ibus-gtk3 既導入) で本 rm を入れずに ibus 経路が
+# 動いていたのは、Debian の ibus と AppImage 内 libibus の API が偶然一致して
+# いたから。他環境では未保証なので本 rm は v1.24.2 でも残す。
+echo "==> Removing bundled libibus to avoid #532 host drift risk"
 rm -fv "$APPDIR/usr/lib/libibus-1.0.so."* 2>&1 | sed 's/^/  /'
 
 echo "==> Replacing AppRun with logging wrapper (#496)"


### PR DESCRIPTION
## Linux AppImage IME 修正 hotfix (v1.24.2)

v1.24.1 で投入した #532 の修正が CI 配布版では効いていなかったため、再ホットフィックス。実機 (Debian 13 / LXQt / X11 / ibus-mozc) で v1.24.1 AppImage を起動して日本語入力が依然として無反応であることを再確認した。

## 誤診の経緯

v1.24.1 の修正コミット ([4ce3989](https://github.com/pooza/capsicum/commit/4ce3989)) ではこう書いた:

> linuxdeploy-plugin-gtk が ldd 経由で libibus-1.0.so.5 を `\$APPDIR/usr/lib/` に同梱するが、これがホスト ibus-daemon との DBus protocol drift を起こし、日本語 IME (ibus-mozc 等) が一切効かなくなる

が、v1.24.1 AppImage を展開して中身を確認すると:

- `libibus-1.0.so.5` は **AppImage に同梱されていない** (v1.24.0 / v1.24.1 とも `find` の結果は doc のみ)
- v1.24.1 で追加した `rm libibus-1.0.so.*` は **no-op** (削除対象が存在しない)
- v1.24.0 には含まれていた `im-ibus.so` (GTK ibus IM module) が **v1.24.1 では消失**
- `immodules.cache` の ibus エントリも欠落

## 真因

[.github/workflows/linux-release.yml](.github/workflows/linux-release.yml) の `apt-get install` リストに **`ibus-gtk3` が含まれていない**。

CI runner (ubuntu-22.04) には `ibus-gtk3` が標準で入っていないため、ホストに `im-ibus.so` が存在せず linuxdeploy-plugin-gtk が AppImage に bundle できない。結果として GTK が ibus module を解決できず、\`GTK_IM_MODULE=ibus\` を立てても無効化される。

v1.24.0 に im-ibus.so が同梱されていたのは、CI runner image に偶然 ibus-gtk3 が入っていた時期があったため (もしくは Phase 4 実装当時の runner image 差分)。v1.24.1 ビルド時には消えていた。

pooza さんが手元で v1.24.1 build.sh を動かして動作確認に成功していたのは、手元の Debian 13 に `ibus-gtk3` が導入済みで `im-ibus.so` が bundle されていたから。「手元では動くが CI 配布版では動かない」の典型例。

## 修正内容

- `.github/workflows/linux-release.yml`: apt-get install に **`ibus-gtk3`** を追加
- `packaging/linux/appimage/build.sh`: 当初仮説のコメントを真因に合わせて訂正。\`rm libibus-1.0.so.*\` は引き続き残す (host ibus-daemon と libibus の version を必ず揃えるため。Flatpak も同じ方針)
- `packages/capsicum/pubspec.yaml`: 1.24.1+66 → 1.24.2+67

## 対象プラットフォーム

**Linux のみ**。Android / iOS / macOS は v1.24.0+65 で問題なく動作中のため再提出しない。

## 検証計画

- マージ後 v1.24.2 タグを打って CI で AppImage を再生成
- 生成された AppImage に `im-ibus.so` / `immodules.cache` の ibus エントリが含まれていることを確認
- 実機 (Debian 13 / LXQt / X11 / ibus-mozc) で日本語入力が動作することを確認

## 既知の不具合

- #54 ATOK で日本語入力が二重になる (Flutter 上流対応待ち)
- #463 入力エラーが出る (GooglePlay 版) — Samsung Keyboard 干渉疑い、報告者協力で再現条件確認中