### PR TITLE
release: v1.24.3 (Linux AppImage hotfix 3 — #532 真因解明 / libibus 同梱)

### DIFF
--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.24.2+67
+version: 1.24.3+68
 
 environment:
   sdk: ^3.11.0

--- a/packaging/linux/appimage/build.sh
+++ b/packaging/linux/appimage/build.sh
@@ -138,30 +138,34 @@ linuxdeploy \
   --desktop-file "$APPDIR/usr/share/applications/$APP_ID.desktop" \
   --icon-file "$APPDIR/$APP_ID.png"
 
-# bundled libibus を除去する (#532)。
+# libibus-1.0.so.5 を AppDir に明示コピーする (#532)。
 #
-# 経緯 (v1.24.1 → v1.24.2 訂正):
-# v1.24.1 リリース時は「linuxdeploy-plugin-gtk が ldd 経由で libibus-1.0.so.5
-# をバンドルしホスト ibus-daemon との DBus protocol drift を起こしている」
-# という仮説で本 rm を追加した。しかし真因は別で、CI runner (ubuntu-22.04)
-# に ibus-gtk3 がインストールされておらず im-ibus.so 自体が host に存在せず
-# AppImage に bundle されていない、つまり ibus 経路が完全に欠落していたこと
-# だった。v1.24.2 で workflow に ibus-gtk3 を追加して im-ibus.so が bundle
-# されるようにした結果、im-ibus.so / libibus-1.0.so.5 がどちらも bundle される
-# 状態になる。
+# 経緯 (v1.24.0 〜 v1.24.3 真因解明):
+# linuxdeploy-plugin-gtk は ldd 経由で im-ibus.so を AppImage に bundle するが、
+# その依存 libibus-1.0.so.5 は (理由不明だが) bundle しない。host 側 libibus
+# を ld.so.cache 経由で引かせると、新しい host libibus が要求する GLib symbol
+# (g_task_set_static_name 等。GLib 2.76 以降) が bundled GLib (build host
+# ubuntu-22.04 = GLib 2.72) で解決できず、IM context 'ibus' のロードに失敗
+# する。具体例: Debian 13 / GLib 2.84 系の host で `Loading IM context type
+# 'ibus' failed` + `undefined symbol: g_task_set_static_name` が stderr に出る。
 #
-# その上で libibus 本体は AppDir から除去し、ホスト側 libibus
-# (/lib/x86_64-linux-gnu/libibus-1.0.so.5) を ld.so.cache 経由で引かせる。
-# im-ibus.so の DT_NEEDED は libibus-1.0.so.5 で、RUNPATH/RPATH に AppDir が
-# 無くても解決される。host ibus-daemon と libibus の version を必ず一致させる
-# ことで protocol drift リスクを最小化する (Flatpak が同じ方針 = runtime 提供
-# の libibus + ibus-daemon 揃え、で問題なく動いている)。
+# v1.24.0 / v1.24.1 / v1.24.2 まではこの mismatch を見逃しており、当初は
+# 「bundled libibus と host ibus-daemon の DBus protocol drift」「im-ibus.so
+# 不足」と二段階の誤診を経た。真因は GLib version mismatch。
 #
-# pooza の手元 (Debian 13 + ibus-gtk3 既導入) で本 rm を入れずに ibus 経路が
-# 動いていたのは、Debian の ibus と AppImage 内 libibus の API が偶然一致して
-# いたから。他環境では未保証なので本 rm は v1.24.2 でも残す。
-echo "==> Removing bundled libibus to avoid #532 host drift risk"
-rm -fv "$APPDIR/usr/lib/libibus-1.0.so."* 2>&1 | sed 's/^/  /'
+# 対処として AppImage 内に libibus を明示同梱する。bundled GLib と同世代の
+# libibus (build host = ubuntu-22.04 の libibus-1.0-5) が入るため symbol
+# resolution は成立する。host ibus-daemon との DBus protocol は libibus 1.5
+# 系で安定しており、Flatpak (org.gnome.Platform 提供 libibus + host ibus-daemon)
+# が問題なく動いていることから drift リスクは小さいと判断。
+echo "==> Bundling libibus into AppDir (host libibus 経由の GLib symbol mismatch を避ける)"
+HOST_LIBIBUS_DIR=/usr/lib/x86_64-linux-gnu
+if compgen -G "$HOST_LIBIBUS_DIR/libibus-1.0.so.*" > /dev/null; then
+  cp -av "$HOST_LIBIBUS_DIR"/libibus-1.0.so.* "$APPDIR/usr/lib/" 2>&1 | sed 's/^/  /'
+else
+  echo "ERROR: $HOST_LIBIBUS_DIR/libibus-1.0.so.* not found. Install libibus-1.0-5 (ibus-gtk3 brings it)." >&2
+  exit 1
+fi
 
 echo "==> Replacing AppRun with logging wrapper (#496)"
 # linuxdeploy が生成する AppRun は exec で wrapped を呼ぶだけで、stderr が


### PR DESCRIPTION
## Linux AppImage の日本語 IME 修正 hotfix (真因解明)

v1.24.2 で投入した #532 対応 (CI runner に ibus-gtk3 追加) でも実機 (Debian 13 / LXQt / X11 / ibus-mozc) で日本語入力ができないことを確認 → AppRun のログから真因を特定し再ホットフィックス。

## 真因 (3 度目)

AppRun のログに以下:

\`\`\`
Gtk-WARNING: /lib/x86_64-linux-gnu/libibus-1.0.so.5: undefined symbol: g_task_set_static_name
Gtk-WARNING: Loading IM context type 'ibus' failed
\`\`\`

\`g_task_set_static_name\` は GLib 2.76 で追加されたシンボル。

- ホスト Debian 13 の GLib は 2.84+ → 同梱の libibus はこのシンボルを要求する
- AppImage 内の bundled libglib は build host (ubuntu-22.04 / GLib 2.72) ベースで古い → 該当シンボルなし
- AppImage 起動時、bundled GLib が先にロードされ、その後 host libibus が dlopen されると symbol resolution failure → IM context 'ibus' が読み込めない

## v1.24.0 〜 v1.24.2 すべてで起きていた

| version | im-ibus.so | libibus 同梱 | 結果 |
|---|---|---|---|
| v1.24.0 | ✓ | × | host libibus + bundled GLib mismatch → 失敗 |
| v1.24.1 | × (CI 環境変化) | × | そもそも ibus 経路なし → 失敗 |
| v1.24.2 | ✓ (CI に ibus-gtk3 追加) | × (rm libibus) | v1.24.0 と同じ mismatch → 失敗 |
| **v1.24.3** | ✓ | **✓ (build host から AppDir に明示コピー)** | symbol 解決成立 → 動作する見込み |

#532 当初の「bundled libibus と host ibus-daemon の DBus protocol drift」仮説 (v1.24.1)、[PR #535](https://github.com/pooza/capsicum/pull/535) で書いた「im-ibus.so 不足」仮説 (v1.24.2)、どちらも症状の一部しか説明していなかった。本丸は **GLib version mismatch**。

## 修正内容

[packaging/linux/appimage/build.sh](packaging/linux/appimage/build.sh): linuxdeploy 完了後、build host (ubuntu-22.04 / GLib 2.72) の \`/usr/lib/x86_64-linux-gnu/libibus-1.0.so.*\` を AppDir/usr/lib/ に明示コピー。\`rm libibus-1.0.so.*\` (v1.24.1/v1.24.2) は削除。bundled GLib と同世代の libibus が AppImage 内で完結する。

host ibus-daemon との DBus protocol drift リスクは libibus 1.5 系の安定性 + Flatpak (org.gnome.Platform 提供 libibus + host ibus-daemon が運用上問題なく動いている) を根拠に許容判断。

[packages/capsicum/pubspec.yaml](packages/capsicum/pubspec.yaml): 1.24.2+67 → 1.24.3+68

## v1.24.2 の扱い

draft Release / タグともに削除済み (\`gh release delete v1.24.2 --cleanup-tag\`)。v1.24.2 のマージコミット (#535) は main 履歴に残るが、リリースとしては v1.24.1 → v1.24.3 で連続する形になる。

## 対象プラットフォーム

**Linux のみ**。Android / iOS / macOS は v1.24.0+65 で問題なく動作中のため再提出しない。

## 検証計画

1. CI で AppImage 再ビルド完了後、AppImage を展開して以下を確認:
   - \`usr/lib/libibus-1.0.so.5\` が同梱されている
   - \`usr/lib/gtk-3.0/3.0.0/immodules/im-ibus.so\` が同梱されている
   - \`immodules.cache\` に ibus エントリがある
2. 実機 (Debian 13 / LXQt / X11 / ibus-mozc) で AppImage を起動 → 投稿欄で日本語変換ができることを pooza さんに確認してもらう
3. AppRun ログ (\`~/.local/share/capsicum/logs/\`) で \`Loading IM context type 'ibus' failed\` が消えていることを確認

## 関連

- [#532](https://github.com/pooza/capsicum/issues/532) (closed): 当初の Issue
- [#535](https://github.com/pooza/capsicum/pull/535) (merged): v1.24.2 hotfix。誤診の経緯 (2 段階)
- [#536](https://github.com/pooza/capsicum/issues/536): fcitx5 / uim 対応 + CI assertion (回帰防止) を v1.25 候補で検討