### PR TITLE
release: v1.24.4 (Linux AppImage hotfix 4 — #536 fcitx5 / uim immodule 同梱 + #533 Codex P2)

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -36,20 +36,27 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # ibus-gtk3 を入れる理由 (#532 真因対応 / v1.24.2):
-          # GTK の ibus IM モジュール (im-ibus.so) は host にインストール
-          # されていないと linuxdeploy-plugin-gtk が AppImage に bundle で
-          # きない。CI runner (ubuntu-22.04) には標準で入っていないため、
-          # 配布 AppImage の immodules.cache から ibus エントリが欠落し、
-          # GTK_IM_MODULE=ibus を立てても解決できず日本語入力が一切
-          # 効かない状態だった。
+          # GTK IM module を host から入れる理由 (#532 真因対応 / v1.24.2 + #536 / v1.24.4):
+          # GTK の IM module (im-ibus.so / im-fcitx5.so / im-uim.so) は host に
+          # インストールされていないと linuxdeploy-plugin-gtk が AppImage に
+          # bundle できない。CI runner (ubuntu-22.04) には標準で入っていないため、
+          # 配布 AppImage の immodules.cache から該当エントリが欠落し、
+          # GTK_IM_MODULE=ibus / fcitx5 / uim を立てても解決できず日本語入力が
+          # 一切効かない状態だった。
+          #
+          # v1.24.4 (#536) で fcitx5 / uim の immodule も同梱対象に拡張。
+          # ただし pooza 検証環境は ibus-mozc のみで、fcitx5 / uim は **未検証**。
+          # libfcitx5* / libuim* の明示同梱 (libibus と同型の GLib symbol mismatch
+          # 対策) は配布後の不具合報告ベースで対応する best-effort 方針。
           sudo apt-get update
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config \
             libgtk-3-dev libsecret-1-dev libwebkit2gtk-4.1-dev \
             libcurl4-openssl-dev default-jdk-headless \
             libfuse2 patchelf \
-            ibus-gtk3
+            ibus-gtk3 \
+            fcitx5-frontend-gtk3 \
+            uim-gtk3-immodule
 
       - name: Install linuxdeploy / appimagetool (with sha256 pin)
         # continuous / master という rolling アップデート tag から DL するが、

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ capsicum が提案するのは、アプリ単体の体験ではなく、サー�
 
 [![Get it on Google Play](https://img.shields.io/badge/GET_IT_ON-Google_Play-000000?style=for-the-badge&logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=net.shrieker.capsicum)
 [![Download on the App Store](https://img.shields.io/badge/Download_on_the-App_Store-000000?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/jp/app/capsicum/id6760206608)
+[![Linux AppImage](https://img.shields.io/badge/Linux-AppImage-000000?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/pooza/capsicum/releases/latest)
+
+Linux 版は [GitHub Releases](https://github.com/pooza/capsicum/releases) から AppImage (x86_64) を配布しています。Flathub への提出は再申請手続き中です。
+
+### Linux の日本語入力（IM）について
+
+GTK IM module の `ibus` / `fcitx5` / `uim` を AppImage に同梱しています。開発者環境では `ibus-mozc` のみ動作確認済みで、`fcitx5` / `uim` 経路は **未検証 (best-effort)** です。これらの IM で動作しない場合は [Issue](https://github.com/pooza/capsicum/issues) にご報告ください。
 
 ## モロヘイヤ連携
 

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.24.3+68
+version: 1.24.4+69
 
 environment:
   sdk: ^3.11.0

--- a/packaging/linux/appimage/build.sh
+++ b/packaging/linux/appimage/build.sh
@@ -215,6 +215,30 @@ exit "${PIPESTATUS[0]}"
 APPRUN_EOF
 chmod +x "$APPDIR/AppRun"
 
+# v1.24.1 → v1.24.2 で CI runner image の構成変化により im-ibus.so が
+# 静かに同梱されなくなる事故があった。回帰防止のため、GTK IM module の
+# bundle と immodules.cache 登録を mechanical に検証する (#536)。
+# fcitx5 / uim は best-effort (動作未検証) だが、CI assertion 自体は
+# 同等にかける。
+echo "==> Verifying GTK IM module bundling (regression guard, #536)"
+IM_DIR="$APPDIR/usr/lib/gtk-3.0/3.0.0/immodules"
+IM_CACHE="$APPDIR/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+if [ ! -f "$IM_CACHE" ]; then
+  echo "ERROR: immodules.cache not found at $IM_CACHE" >&2
+  exit 1
+fi
+for module in im-ibus.so im-fcitx5.so im-uim.so; do
+  if [ ! -f "$IM_DIR/$module" ]; then
+    echo "ERROR: $module not bundled at $IM_DIR/$module" >&2
+    exit 1
+  fi
+  if ! grep -q "\"$module\"" "$IM_CACHE"; then
+    echo "ERROR: $module not registered in immodules.cache" >&2
+    exit 1
+  fi
+  echo "  OK: $module bundled and registered"
+done
+
 echo "==> Sealing AppImage with appimagetool"
 FINAL="$DIST_DIR/${APP_NAME}-${VERSION}-x86_64.AppImage"
 ARCH=x86_64 appimagetool "$APPDIR" "$FINAL"

--- a/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
+++ b/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
@@ -48,6 +48,9 @@
   </screenshots>
 
   <releases>
+    <release version="1.24.4" date="2026-05-11"/>
+    <release version="1.24.3" date="2026-05-11"/>
+    <release version="1.24.1" date="2026-05-10"/>
     <release version="1.24.0" date="2026-05-10"/>
   </releases>
 </component>


### PR DESCRIPTION
## Linux AppImage の IM 経路拡大 (best-effort)

v1.24.3 で日本語 IME (ibus-mozc) は配布版でも動作するようになったが、pooza 検証環境は ibus-mozc のみで、Linux で同等にメジャーな **fcitx5** / **uim** は未対応のまま放置されていた (#536)。v1.24.4 で immodule 同梱と CI assertion を投入する。

### 対応内容

| 件 | 変更 |
|---|---|
| #536 | `linux-release.yml` の apt-get install に `fcitx5-frontend-gtk3` / `uim-gtk3-immodule` を追加 → `im-fcitx5.so` / `im-uim.so` が AppImage に bundle される |
| #536 | `build.sh` の seal 直前に IM module の bundle と `immodules.cache` 登録を mechanical に検証する assertion を追加。v1.24.1 → v1.24.2 で発生した「CI runner image の構成変化で `im-ibus.so` が静かに消える」事故を再発時に検出できる |
| #533 (Codex P2) | `metainfo.xml` の `<releases>` を 1.24.0 のみから 1.24.0 / 1.24.1 / 1.24.3 / 1.24.4 まで補完 (v1.24.2 は配信実態なし) |
| docs | README に Linux AppImage バッジ (v1.24.0 配布開始時の漏れ補完) と「Linux の日本語入力 (IM)」節 (best-effort スタンス) を追加 |

### スタンス

**fcitx5 / uim 経路は未検証 (best-effort)**。pooza 検証環境は ibus-mozc のみ。`libfcitx5*` / `libuim*` の明示同梱 (libibus と同型の GLib symbol mismatch 対策) は配布後の不具合報告ベースで対応する方針。README とリリースノートに「動かない場合は Issue 報告を」と明示。

### v1.24.4 で同居しないもの

- v1.24.1〜v1.24.3 の経緯整理 (#532 / #535 / #537 に既収) → 触らない
- Android / iOS / macOS は v1.24.0+65 のまま再提出しない (Linux 限定 hotfix)

### CI

linux-release.yml は本 PR で変更があるので CI が回る。`fcitx5-frontend-gtk3` / `uim-gtk3-immodule` のパッケージ名が Ubuntu 22.04 リポジトリと整合するか、および新規 assertion が通るかを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)