### PR TITLE
release: v1.27.1 (#607 Post.isHtml リグレッション ホットフィックス)

### DIFF
--- a/packages/capsicum/lib/src/provider/timeline_provider.dart
+++ b/packages/capsicum/lib/src/provider/timeline_provider.dart
@@ -381,26 +381,7 @@ class TimelineNotifier extends AutoDisposeAsyncNotifier<TimelineState> {
       if (p.id == updated.id) return updated;
       // Also check reblog target.
       if (p.reblog?.id == updated.id) {
-        return Post(
-          id: p.id,
-          postedAt: p.postedAt,
-          author: p.author,
-          content: p.content,
-          scope: p.scope,
-          attachments: p.attachments,
-          favouriteCount: p.favouriteCount,
-          reblogCount: p.reblogCount,
-          replyCount: p.replyCount,
-          quoteCount: p.quoteCount,
-          favourited: p.favourited,
-          reblogged: p.reblogged,
-          bookmarked: p.bookmarked,
-          reactions: p.reactions,
-          myReaction: p.myReaction,
-          reactionEmojis: p.reactionEmojis,
-          inReplyToId: p.inReplyToId,
-          reblog: updated,
-        );
+        return p.copyWith(reblog: updated);
       }
       return p;
     }).toList();
@@ -626,43 +607,7 @@ class TimelineNotifier extends AutoDisposeAsyncNotifier<TimelineState> {
     final author = _maybeCatUser(p.author);
     final reblog = p.reblog != null ? _applyIsCat(p.reblog!) : null;
     if (identical(author, p.author) && identical(reblog, p.reblog)) return p;
-    return Post(
-      id: p.id,
-      postedAt: p.postedAt,
-      author: author,
-      content: p.content,
-      scope: p.scope,
-      attachments: p.attachments,
-      favouriteCount: p.favouriteCount,
-      reblogCount: p.reblogCount,
-      replyCount: p.replyCount,
-      quoteCount: p.quoteCount,
-      favourited: p.favourited,
-      reblogged: p.reblogged,
-      bookmarked: p.bookmarked,
-      sensitive: p.sensitive,
-      reactions: p.reactions,
-      myReaction: p.myReaction,
-      reactionEmojis: p.reactionEmojis,
-      inReplyToId: p.inReplyToId,
-      reblog: reblog,
-      quote: p.quote,
-      quoteState: p.quoteState,
-      spoilerText: p.spoilerText,
-      emojis: p.emojis,
-      emojiHost: p.emojiHost,
-      card: p.card,
-      poll: p.poll,
-      filterAction: p.filterAction,
-      filterTitle: p.filterTitle,
-      pinned: p.pinned,
-      channelId: p.channelId,
-      channelName: p.channelName,
-      localOnly: p.localOnly,
-      quotable: p.quotable,
-      language: p.language,
-      url: p.url,
-    );
+    return p.copyWith(author: author, reblog: reblog);
   }
 
   User _maybeCatUser(User user) {

--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -244,39 +244,7 @@ class _PostTileState extends ConsumerState<PostTile> {
     Post displayPost,
     List<Attachment> updatedAttachments,
   ) {
-    final updatedPost = Post(
-      id: displayPost.id,
-      postedAt: displayPost.postedAt,
-      author: displayPost.author,
-      content: displayPost.content,
-      scope: displayPost.scope,
-      attachments: updatedAttachments,
-      favouriteCount: displayPost.favouriteCount,
-      reblogCount: displayPost.reblogCount,
-      replyCount: displayPost.replyCount,
-      quoteCount: displayPost.quoteCount,
-      favourited: displayPost.favourited,
-      reblogged: displayPost.reblogged,
-      bookmarked: displayPost.bookmarked,
-      sensitive: displayPost.sensitive,
-      reactions: displayPost.reactions,
-      myReaction: displayPost.myReaction,
-      reactionEmojis: displayPost.reactionEmojis,
-      inReplyToId: displayPost.inReplyToId,
-      reblog: displayPost.reblog,
-      quote: displayPost.quote,
-      spoilerText: displayPost.spoilerText,
-      emojis: displayPost.emojis,
-      emojiHost: displayPost.emojiHost,
-      card: displayPost.card,
-      poll: displayPost.poll,
-      filterAction: displayPost.filterAction,
-      filterTitle: displayPost.filterTitle,
-      pinned: displayPost.pinned,
-      channelId: displayPost.channelId,
-      channelName: displayPost.channelName,
-      localOnly: displayPost.localOnly,
-    );
+    final updatedPost = displayPost.copyWith(attachments: updatedAttachments);
     ref.read(timelineProvider.notifier).updatePost(updatedPost);
   }
 

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.27.0+78
+version: 1.27.1+79
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum_core/lib/src/model/post.dart
+++ b/packages/capsicum_core/lib/src/model/post.dart
@@ -88,14 +88,16 @@ class Post {
     this.url,
   });
 
-  /// 派生オブジェクトを生成する。現状は enrich パイプライン（IsCatEnricher 等）
-  /// で author / reblog だけを差し替える用途で使用。フィールド追加時の
-  /// 取りこぼし防止のため、新フィールドの追加はここに追従する。
+  /// 派生オブジェクトを生成する。enrich パイプライン（IsCatEnricher 等）の
+  /// author / reblog 差し替え、添付説明（ALT）編集後の attachments 差し替え等で
+  /// 使用。フィールド追加時の取りこぼし防止のため、新フィールドの追加はここに
+  /// 追従する。
   Post copyWith({
     User? author,
     Post? reblog,
     bool? reblogged,
     int? reblogCount,
+    List<Attachment>? attachments,
   }) => Post(
     id: id,
     postedAt: postedAt,
@@ -103,7 +105,7 @@ class Post {
     content: content,
     isHtml: isHtml,
     scope: scope,
-    attachments: attachments,
+    attachments: attachments ?? this.attachments,
     favouriteCount: favouriteCount,
     reblogCount: reblogCount ?? this.reblogCount,
     replyCount: replyCount,

--- a/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
+++ b/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
@@ -48,6 +48,10 @@
   </screenshots>
 
   <releases>
+    <release version="1.27.1" date="2026-05-23"/>
+    <release version="1.27.0" date="2026-05-22"/>
+    <release version="1.26.0" date="2026-05-15"/>
+    <release version="1.25.0" date="2026-05-12"/>
     <release version="1.24.4" date="2026-05-11"/>
     <release version="1.24.3" date="2026-05-11"/>
     <release version="1.24.1" date="2026-05-10"/>


### PR DESCRIPTION
## #607 ホットフィックス

v1.27.0 で `Post.isHtml` フィールドを追加した #578 で、Post を生コンストラクタで再構築している 3 経路が `isHtml` を渡し忘れていたためデフォルトの `false` に落ち、Mastodon 投稿 (toCapsicum で `isHtml: true` 設定) が enrich / 更新経路で `isHtml: false` 化されて `renderMfm` に流れ、`<p>` / `<a href="...">` / `<br>` 等の生 HTML タグが本文に露出する不具合を修正。

### 影響経路

| 経路 | 頻度 | トリガー |
|---|---|---|
| `timeline_provider.dart _applyIsCat` | **TL fetch ごと**。連合 Misskey 猫耳ユーザーが TL にいれば毎回ヒット | 高: 美食丼 TL でリグレッション観測済 (きゅあすきー管理人さんの投稿で raw HTML 露出) |
| `post_tile.dart _onMediaDescriptionUpdated` | 低 (能動アクション時のみ) | Mastodon 投稿の添付説明 (ALT) を編集 |
| `timeline_provider.dart updatePost` の reblog 置換 | 中 (reblog にお気に入りした時等) | `isHtml` 以外も大量フィールドを同時に落としていた |

backends 側 (`mastodon/extensions.dart` 等) は明示的に `isHtml` をセットしているため問題なし。app 層 3 箇所のみ。

### 修正

3 経路とも [`Post.copyWith`](packages/capsicum_core/lib/src/model/post.dart) 経由に置換。`copyWith` は `isHtml` を含む全フィールドを継承するため、`IsCatEnricher._enrichPost` (is_cat_provider.dart) 側と同じ安全な実装に揃う。`post.dart` の `copyWith` に `attachments` 引数を追加して `_onMediaDescriptionUpdated` を吸収。

### 発見経緯

#578 リリース時の Codex line comment (ID 3287006505) が同型の指摘 (P1) を出していたが、当時の同期で **review 本体の About box のみを見て空振り判定**してしまい、line comment 側の実体ある指摘を取りこぼした。v1.27.0 リリース後の進捗同期で再評価し、実コードを検証して risk 確認 → #607 起票 → ホットフィックス決定。

経緯の詳細と再発防止 (Codex line comment と review 本体を両方見る運用、空振り判定の運用記録) は #607 と pooza のセッションメモリに記録済み。

### #600 (Mastodon streaming 管理者マーキング) の扱い

develop に乗っている #600 fix は **v1.26.0 由来の pre-existing bug** で v1.27 リグレッションではないため、本ホットフィックスには含めず v1.28 据え置き。気が変わった場合は merge 前に cherry-pick 追加可。

### CI / 検証

- `dart format` / `dart analyze`: クリーン
- `flutter test`: 1 件失敗 (`widget_test.dart` の `App displays capsicum title`) は **main でも失敗する pre-existing なテスト環境 asset 読み込みエラー**で本 PR と無関係
- 美食丼 TL での実機検証 (連合 Misskey 猫耳ユーザーの投稿が正常レンダリングされるか) は内部ベータ build で確認推奨

### 出荷スコープ

iOS / Android / Windows は v1.27.0 公開済みのため、v1.27.1 も同 4 OS が対象。macOS は v1.27.0 が審査中であり、本 PR merge 後の build を 1.27.1 として **macOS のみ +79 で再提出**する選択肢もあり (判断は merge 後)。