### PR TITLE
release: v1.28.1 (#603 Codex P2 hotfix + #594 余波の誤投稿バグ修正)

### DIFF
--- a/packages/capsicum/lib/src/provider/chat_provider.dart
+++ b/packages/capsicum/lib/src/provider/chat_provider.dart
@@ -182,7 +182,10 @@ class ChatThreadListNotifier
     final updated = ChatThread(
       room: existing.room,
       lastMessage: message,
-      isUnread: isIncoming,
+      // DM 経路と同じ式に揃える (#632 review)。room は chat_room_streaming
+      // 側で `defaultIsRead: true` を強制しているため通常は read 扱いだが、
+      // 将来サーバーが unread を返すよう変わっても整合する。
+      isUnread: isIncoming && !message.isRead,
     );
     final filtered = current.where((t) => t.room?.id != roomId).toList();
     state = AsyncData([updated, ...filtered]);

--- a/packages/capsicum/lib/src/provider/chat_provider.dart
+++ b/packages/capsicum/lib/src/provider/chat_provider.dart
@@ -154,6 +154,39 @@ class ChatThreadListNotifier
         .toList();
     state = AsyncData([updated, ...filtered]);
   }
+
+  /// chatRoom channel 経由で受信した room message を thread list に反映する
+  /// (#632)。閉じているルームのメッセージは元々届かないが、開いているルームで
+  /// 他メンバーが発言した際に thread list が並び替わらない / 未読が更新され
+  /// ない問題を解消する。room 入室画面 (ChatRoomTimelineNotifier) から呼び
+  /// 出される。
+  void applyRoomMessage(ChatMessage message) {
+    if (!message.isRoomMessage) return;
+    final myUserId = ref.read(currentAccountProvider)?.user.id;
+    if (myUserId == null) return;
+    final roomId = message.toRoom?.id ?? message.toRoomId;
+    if (roomId == null) return;
+    final current = state.valueOrNull ?? const <ChatThread>[];
+    ChatThread? existing;
+    for (final t in current) {
+      if (t.room?.id == roomId) {
+        existing = t;
+        break;
+      }
+    }
+    // 未掲載のルーム = 自分が所属しているが getRoomHistory の結果に含まれない
+    // (空ルーム新規参加直後など)。履歴側を refresh するのが筋だが、ホット
+    // フィックスでは既知 thread のみ更新するに留める。
+    if (existing == null) return;
+    final isIncoming = message.fromUser.id != myUserId;
+    final updated = ChatThread(
+      room: existing.room,
+      lastMessage: message,
+      isUnread: isIncoming,
+    );
+    final filtered = current.where((t) => t.room?.id != roomId).toList();
+    state = AsyncData([updated, ...filtered]);
+  }
 }
 
 /// 特定ルーム (roomId) の chatRoom channel 由来の新着メッセージ broadcast
@@ -328,6 +361,10 @@ class ChatRoomTimelineNotifier
     // ので普通は他ルームが来ないが、サーバー側 race / 取り違え保険。
     if (!message.isRoomMessage) return;
     if (message.toRoomId != null && message.toRoomId != roomId) return;
+    // thread list (chat 履歴) にも反映して並び替え / 未読更新を起こす (#632)。
+    // ChatThreadListNotifier 単独では chatRoom channel を購読しないため、
+    // 開いている room 側から都度流す経路。
+    ref.read(chatThreadListProvider.notifier).applyRoomMessage(message);
     final current = state.valueOrNull;
     if (current == null) return;
     if (current.messages.any((m) => m.id == message.id)) return;

--- a/packages/capsicum/lib/src/ui/screen/pages_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/pages_screen.dart
@@ -1,5 +1,4 @@
-import 'package:capsicum_core/capsicum_core.dart' as cc;
-import 'package:capsicum_core/capsicum_core.dart' hide Page;
+import 'package:capsicum_core/capsicum_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -23,7 +22,9 @@ class PagesScreen extends ConsumerStatefulWidget {
 
 class _PagesScreenState extends ConsumerState<PagesScreen> {
   final _scrollController = ScrollController();
-  List<cc.Page> _likedPages = [];
+  // ライクエントリ単位で保持する (#631)。pagination cursor として渡すべきは
+  // ページ ID ではなく `LikedPageEntry.likeId` の方。
+  List<LikedPageEntry> _likedEntries = [];
   bool _loadingLiked = true;
   bool _loadingMoreLiked = false;
   bool _hasMoreLiked = true;
@@ -56,14 +57,14 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
       return;
     }
     try {
-      final pages = await (adapter as PagesSupport).getLikedPages(
+      final entries = await (adapter as PagesSupport).getLikedPages(
         query: const TimelineQuery(limit: 20),
       );
       if (mounted) {
         setState(() {
-          _likedPages = pages;
+          _likedEntries = entries;
           _loadingLiked = false;
-          _hasMoreLiked = pages.length >= 20;
+          _hasMoreLiked = entries.length >= 20;
         });
       }
     } catch (e, st) {
@@ -83,7 +84,7 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
   }
 
   Future<void> _loadMoreLiked() async {
-    if (_loadingMoreLiked || !_hasMoreLiked || _likedPages.isEmpty) return;
+    if (_loadingMoreLiked || !_hasMoreLiked || _likedEntries.isEmpty) return;
     setState(() => _loadingMoreLiked = true);
 
     final adapter = ref.read(currentAdapterProvider);
@@ -93,11 +94,11 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
     }
     try {
       final older = await (adapter as PagesSupport).getLikedPages(
-        query: TimelineQuery(maxId: _likedPages.last.id, limit: 20),
+        query: TimelineQuery(maxId: _likedEntries.last.likeId, limit: 20),
       );
       if (mounted) {
         setState(() {
-          _likedPages = [..._likedPages, ...older];
+          _likedEntries = [..._likedEntries, ...older];
           _loadingMoreLiked = false;
           _hasMoreLiked = older.length >= 20;
         });
@@ -121,7 +122,7 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
   Future<void> _refresh() async {
     setState(() {
       _loadingLiked = true;
-      _likedPages = [];
+      _likedEntries = [];
       _hasMoreLiked = true;
     });
     await _loadLiked();
@@ -157,7 +158,7 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
             ),
           ),
         ),
-        if (_likedPages.isEmpty)
+        if (_likedEntries.isEmpty)
           const SliverToBoxAdapter(
             child: Padding(
               padding: EdgeInsets.all(16),
@@ -168,15 +169,18 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
           SliverPadding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             sliver: SliverList(
-              delegate: SliverChildBuilderDelegate((context, index) {
-                if (index >= _likedPages.length) {
-                  return const Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-                return PageCard(page: _likedPages[index]);
-              }, childCount: _likedPages.length + (_loadingMoreLiked ? 1 : 0)),
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  if (index >= _likedEntries.length) {
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  return PageCard(page: _likedEntries[index].page);
+                },
+                childCount: _likedEntries.length + (_loadingMoreLiked ? 1 : 0),
+              ),
             ),
           ),
         const SliverToBoxAdapter(child: SizedBox(height: 24)),

--- a/packages/capsicum/lib/src/ui/screen/pages_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/pages_screen.dart
@@ -28,6 +28,9 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
   bool _loadingLiked = true;
   bool _loadingMoreLiked = false;
   bool _hasMoreLiked = true;
+  // _refresh が走った瞬間に in-flight の _loadMoreLiked が古い cursor 由来
+  // の結果を空配列にマージしてしまう race を防ぐ generation token (#631)。
+  int _loadGeneration = 0;
 
   @override
   void initState() {
@@ -85,24 +88,26 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
 
   Future<void> _loadMoreLiked() async {
     if (_loadingMoreLiked || !_hasMoreLiked || _likedEntries.isEmpty) return;
+    final gen = _loadGeneration;
     setState(() => _loadingMoreLiked = true);
 
     final adapter = ref.read(currentAdapterProvider);
     if (adapter is! PagesSupport) {
-      if (mounted) setState(() => _loadingMoreLiked = false);
+      if (mounted && gen == _loadGeneration) {
+        setState(() => _loadingMoreLiked = false);
+      }
       return;
     }
     try {
       final older = await (adapter as PagesSupport).getLikedPages(
         query: TimelineQuery(maxId: _likedEntries.last.likeId, limit: 20),
       );
-      if (mounted) {
-        setState(() {
-          _likedEntries = [..._likedEntries, ...older];
-          _loadingMoreLiked = false;
-          _hasMoreLiked = older.length >= 20;
-        });
-      }
+      if (!mounted || gen != _loadGeneration) return;
+      setState(() {
+        _likedEntries = [..._likedEntries, ...older];
+        _loadingMoreLiked = false;
+        _hasMoreLiked = older.length >= 20;
+      });
     } catch (e, st) {
       Sentry.captureException(
         scrubException(e),
@@ -111,7 +116,7 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
           scope.setTag('pages.op', 'load_more_liked');
         },
       );
-      if (!mounted) return;
+      if (!mounted || gen != _loadGeneration) return;
       setState(() => _loadingMoreLiked = false);
       ScaffoldMessenger.of(
         context,
@@ -121,7 +126,9 @@ class _PagesScreenState extends ConsumerState<PagesScreen> {
 
   Future<void> _refresh() async {
     setState(() {
+      _loadGeneration++;
       _loadingLiked = true;
+      _loadingMoreLiked = false;
       _likedEntries = [];
       _hasMoreLiked = true;
     });

--- a/packages/capsicum/lib/src/ui/widget/simple_post_bar.dart
+++ b/packages/capsicum/lib/src/ui/widget/simple_post_bar.dart
@@ -36,12 +36,9 @@ class SimplePostBar extends ConsumerStatefulWidget {
   ConsumerState<SimplePostBar> createState() => _SimplePostBarState();
 }
 
-class _SimplePostBarState extends ConsumerState<SimplePostBar> {
+class _SimplePostBarState extends ConsumerState<SimplePostBar>
+    with WidgetsBindingObserver {
   final _controller = ShortcodeWarningController();
-  // テキスト欄のフォーカス検出用。MediaQuery.viewInsets は Scaffold body 内で
-  // 剥がされて 0 になるため使えない (#594 の compose_screen 流用が効かない)。
-  // モバイルでフォーカス中 = ソフトキーボード表示中とみなして「しまう」ボタン
-  // を出す。
   final _focusNode = FocusNode();
   bool _sending = false;
   bool _paletteOpen = false;
@@ -49,23 +46,26 @@ class _SimplePostBarState extends ConsumerState<SimplePostBar> {
   @override
   void initState() {
     super.initState();
+    // ソフトキーボード表示中だけ「しまう」ボタンを出すため、metrics 変化を
+    // 受けて rebuild する (#594 / #630)。
+    WidgetsBinding.instance.addObserver(this);
     // テキスト編集のたびに未登録 shortcode を再評価する (#609 / compose_screen
     // の _onTextChanged と同等)。IME 変換中は controller 側の guard で警告
     // 装飾が抑えられるので、ここでは値が変わるたび無条件に流す。
     _controller.addListener(_updateShortcodeWarnings);
-    _focusNode.addListener(_onFocusChanged);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _controller.removeListener(_updateShortcodeWarnings);
     _controller.dispose();
-    _focusNode.removeListener(_onFocusChanged);
     _focusNode.dispose();
     super.dispose();
   }
 
-  void _onFocusChanged() {
+  @override
+  void didChangeMetrics() {
     if (mounted) setState(() {});
   }
 
@@ -247,13 +247,13 @@ class _SimplePostBarState extends ConsumerState<SimplePostBar> {
                 ),
               ),
               const SizedBox(width: 4),
-              // テキスト欄がフォーカス中 = モバイルでソフトキーボード表示中の
-              // ときだけ「しまう」ボタンを出す (#594)。常駐アイコンを増やさず、
-              // IME 側に dismiss ボタンが無い環境 (Android ATOK 等) の fallback。
-              // MediaQuery.viewInsets は Scaffold body 内で剥がされて使えない
-              // ので focus 状態で代替する。デスクトップでもフォーカス時に出るが
-              // クリックで unfocus できるので無害。
-              if (_focusNode.hasFocus)
+              // ソフトキーボードが画面に出ているときだけ「しまう」ボタンを
+              // 出す (#594)。IME 側に dismiss ボタンが無い環境 (Android ATOK
+              // 等) の fallback。Scaffold body 内では MediaQuery.viewInsets
+              // が剥がれて 0 になるため、View.of(context) で root view から
+              // 拾う。focus 判定だと desktop / iPad + 物理キーボード時に
+              // ボタン列が 1 個右にずれて誤投稿が起きていた (#630)。
+              if (View.of(context).viewInsets.bottom > 0)
                 IconButton(
                   icon: const Icon(Icons.keyboard_hide, size: 20),
                   tooltip: 'キーボードをしまう',

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.28.0+81
+version: 1.28.1+82
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum_backends/lib/src/misskey/adapter.dart
+++ b/packages/capsicum_backends/lib/src/misskey/adapter.dart
@@ -1150,18 +1150,22 @@ class MisskeyAdapter extends DecentralizedBackendAdapter
   }
 
   @override
-  Future<List<Page>> getLikedPages({TimelineQuery? query}) async {
+  Future<List<LikedPageEntry>> getLikedPages({TimelineQuery? query}) async {
     final data = await client.getMyPageLikes(
       sinceId: query?.sinceId,
       untilId: query?.maxId,
       limit: query?.limit,
     );
-    // /api/i/page-likes は {id, page} の配列を返すため page を取り出す。
-    return data
-        .map((e) => e['page'] as Map<String, dynamic>?)
-        .whereType<Map<String, dynamic>>()
-        .map(_mapPage)
-        .toList();
+    // /api/i/page-likes は {id, page} の配列を返す。`id` はライクエントリ
+    // 自体の ID で、pagination cursor として渡すべきはこちら (#631)。
+    final entries = <LikedPageEntry>[];
+    for (final e in data) {
+      final likeId = e['id'] as String?;
+      final pageMap = e['page'] as Map<String, dynamic>?;
+      if (likeId == null || pageMap == null) continue;
+      entries.add((likeId: likeId, page: _mapPage(pageMap)));
+    }
+    return entries;
   }
 
   // DriveSupport

--- a/packages/capsicum_core/lib/src/social/interfaces/pages_support.dart
+++ b/packages/capsicum_core/lib/src/social/interfaces/pages_support.dart
@@ -1,6 +1,12 @@
 import '../../model/page.dart';
 import '../../model/timeline_query.dart';
 
+/// like 履歴 1 件分のエントリ。`likeId` はライクエントリ自体の ID で、
+/// `page` がそのライクが指すページ本体。`/api/i/page-likes` の payload は
+/// `{id, page}` 構造で、ここでの `id` は **ライクエントリ ID** であり
+/// ページ ID とは別物 (#631)。
+typedef LikedPageEntry = ({String likeId, Page page});
+
 /// Misskey の Pages 機能 (#186) サポートを宣言する mixin。
 ///
 /// v1 (#186) は読み取り専用。like / unlike は #615、AiScript 動的ブロック
@@ -28,7 +34,10 @@ abstract mixin class PagesSupport {
 
   /// 認証ユーザーが like 済みのページ一覧。
   ///
-  /// Misskey の `POST /api/i/page-likes` 相当。サーバーが認証ユーザーの
+  /// Misskey の `POST /api/i/page-likes` 相当。戻り値は
+  /// `{likeId, page}` の組 (#631): pagination cursor として渡すべきは
+  /// ページ ID ではなくライクエントリ ID。サーバーが認証ユーザーの
   /// like 履歴を保持していない場合は空リストを返す。
-  Future<List<Page>> getLikedPages({TimelineQuery? query}) async => const [];
+  Future<List<LikedPageEntry>> getLikedPages({TimelineQuery? query}) async =>
+      const [];
 }


### PR DESCRIPTION
## Summary

v1.28.0 リリース後に把握した不具合のホットフィックス。v1.28 の主目的機能 (#438 Misskey chat ルーム / #186 Pages 読み取り) に直結する Codex P2 が PR #603 リリース時に未対応のまま merge されていたのと、v1.28 同梱 #594「キーボードをしまう」ボタンが desktop / 物理キーボード接続時の誤投稿を誘発していた件をまとめて消化する。

- **#630** simple_post_bar のフォーカス時にボタン列が 1 個右にずれ、desktop / 物理キーボード接続時に「詳細投稿画面」を押そうとして送信が走る誤投稿バグ。判定軸を `_focusNode.hasFocus` から `View.of(context).viewInsets.bottom > 0` に変更し WidgetsBindingObserver で metrics 変化を観測 (@precure 報告: <https://mk.precure.fun/notes/amq419q8sq>, <https://mk.precure.fun/notes/amq42e8it6>)
- **#631** Misskey Pages いいね一覧の pagination cursor がページ ID で行われていた問題。`PagesSupport.getLikedPages` の戻り値を `List<LikedPageEntry>` に変えてライクエントリ ID を保持
- **#632** chat thread list が chatRoom channel 由来の room message で並び替わらない問題。`ChatThreadListNotifier.applyRoomMessage` を追加し、room timeline 経路から都度反映

縮小版リリース前レビュー (API 契約 / 並行性・ライフサイクル) を実施。赤 0 / 黄 5 で、閾値以下の 2 件 (`#631 _refresh × _loadMoreLiked race` / `#632 isUnread セマンティクス`) は d643bd6 でインライン消化、残り 3 件 (View.of vs MediaQuery 非対称・autoDispose resurrect・閉じたルーム取りこぼし) は v1.30 で扱う。

build 番号は 81 → 82 へ (iOS / macOS / Android / Linux / Windows 全プラットフォーム揃え)。

## Test plan

- [ ] `dart analyze packages/` パス確認 (PR 上 CI)
- [ ] develop の手元で `#630` 再現確認 (Windows MSIX / macOS でフォーカス時ボタン列が動かないこと)
- [ ] `#631` 再現確認 (Misskey ページの「いいねしたページ」一覧をスクロールして重複・抜けなく追加取得されること)
- [ ] `#632` 再現確認 (chat ルーム入室中に他メンバーが発言したら thread list が並び替わる + 未読バッジが付く)