### PR TITLE
v1.31.1: #659 アクションメニューの locale fatal クラッシュ修正 (CAPSICUM-2G)

### DIFF
--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -1151,6 +1151,10 @@ class _PostTileState extends ConsumerState<PostTile> {
     final messenger = ScaffoldMessenger.of(context);
     final boostLabel = ref.read(reblogLabelProvider);
     final bookmarkLabel = adapter is ReactionSupport ? 'お気に入り' : 'ブックマーク';
+    // メニューを開いた時点の locale を確定させておく。BottomSheet の rebuild 時に
+    // 外側 PostTile の context が deactivate 済みだと Localizations.localeOf が
+    // null check で落ちるため、ここで一度だけ解決して閉包に取り込む（#659）。
+    final locale = Localizations.localeOf(context);
 
     showModalBottomSheet(
       context: context,
@@ -1289,8 +1293,7 @@ class _PostTileState extends ConsumerState<PostTile> {
                       adapter.isTranslationAvailable) &&
                   targetPost.scope != PostScope.direct &&
                   post.reblog == null &&
-                  targetPost.language !=
-                      Localizations.localeOf(context).languageCode)
+                  targetPost.language != locale.languageCode)
                 ListTile(
                   leading: const Icon(Icons.translate),
                   title: const Text('翻訳'),

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.31.0+93
+version: 1.31.1+94
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
v1.31.0 リリース当日に観測された投稿アクションメニュー (BottomSheet) の fatal クラッシュ (#659 / Sentry CAPSICUM-2G) のホットフィックス。

翻訳項目の表示条件 `Localizations.localeOf(context)` が外側 PostTile の context を参照しており、BottomSheet の rebuild 時にタイルが deactivate 済み（リスト更新・スクロールアウト）だと null check で fatal クラッシュしていた。メニューを開いた時点で locale を一度だけ解決し閉包に取り込むことで、volatile な context への再依存をなくす（`messenger` / `boostLabel` 等と同じ resolve-before-show パターン）。

- main から release/1.31.1 を分岐し直接 commit（cherry-pick なし）
- pubspec 1.31.1+94
- 縮小版リリース前レビュー（並行性・ライフサイクル観点）赤 0 / 黄 0
- dart format / analyze パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)