### PR TITLE
release: v1.37.1（ナウプレ メタ二重化のホットフィックス #727）

### DIFF
--- a/packages/capsicum/lib/src/util/now_playing_formatter.dart
+++ b/packages/capsicum/lib/src/util/now_playing_formatter.dart
@@ -4,42 +4,41 @@ import 'package:capsicum_core/capsicum_core.dart';
 /// 共有テキスト挿入）もこの定数を参照し、リテラルの二重管理を避ける。
 const nowPlayingTag = '#nowplaying';
 
-/// [NowPlayingInfo] を投稿本文用テキストに整形する **capsicum 側フォールバック**
-/// 整形 (#466 / v1.33)。
+/// [NowPlayingInfo] を投稿本文用テキストに整形する (#466 / v1.33)。
 ///
-/// 整形は本来 2 段（design §URL を持つ源と持たない源）:
+/// テキスト整形は **capsicum 側で完結**させる方針（design §責務分担）。曲メタの
+/// 取得はサーバー（モロヘイヤ enrich `/nowplaying/resolve`）に頼ることがあるが、
+/// **本文の文字列整形はクライアントが正**。モロヘイヤ側の旧ナウプレ整形ハンドラ
+/// （投稿本文の `#nowplaying <url>` 行を見て Title/Album/Artist を書き足す）には
+/// 依存しない。自前メタと旧ハンドラのメタが二重化したため、URL をタグと同一行へ
+/// 置かない形に統一した（#727 二重化対策）。
 ///
-/// 1. モロヘイヤ `text_nowplaying_formatter`（mulukhiya #4382）— プリセット
-///    サーバーで title/artist/album を渡して整形済みテキストを得る。
-/// 2. 本関数 — モロヘイヤ未配備サーバー / オフライン用の最低限フォールバック。
-///    これが無いと「モロヘイヤありき」になり、#466 の「未配備でも動く」制約を
-///    満たせない。
-///
-/// 方針（モロヘイヤ `text_nowplaying_formatter` の出力と揃えた複数行形式）:
+/// 方針（複数行ラベル形式・URL は独立行・タグは裸で末尾）:
 ///
 /// ```
 /// Title: <title>
 /// Album: <album>
 /// Artist: <artist>
-/// #nowplaying <URL があれば>
+/// <URL があれば独立行>
+/// #nowplaying
 /// ```
 ///
 /// - Title / Album / Artist を**取れたものだけ**ラベル付きで列挙する
-///   （MPRIS / SMTC は URL を持たないが title/album/artist を返す）。
-/// - **タグ行は末尾に置く**。[NowPlayingInfo.url] が非 null（Spotify 等）なら
-///   URL を続ける（SNS / モロヘイヤが unfurl する）。
+///   （MPRIS / SMTC / Apple Music は title/album/artist を返す）。
+/// - [NowPlayingInfo.url] が非 null（enrich 補完 / Spotify 等）なら **URL を独立行**
+///   で置く（SNS が unfurl する）。
+/// - **`#nowplaying` は裸で末尾**に固定し、URL や本文を同一行に続けない。
 ///
-///   タグを先頭でなく**末尾**にするのは **モロヘイヤの正規化対策**（#466）。
-///   モロヘイヤは「`#nowplaying` 行に同一行 URL が無いとき次行を詰める」正規化
-///   （過去に `#nowplaying` と URL の間へ改行を入れた投稿を整えるために導入）を
-///   行う。タグを先頭に置くと、URL の無い MPRIS / SMTC では `#nowplaying` 行に
-///   続く `Title:` 行が詰められて結合してしまう。末尾に置けば詰める対象の次行が
-///   無く、副作用が出ない。**先頭に戻さないこと。**
-/// - メタデータが 1 つも無ければ、URL があればそれだけ、無ければ源アプリ名、
-///   それも空なら裸のタグ（いずれも単一行なので正規化の影響を受けない）。
+///   モロヘイヤは「`#nowplaying` 行の直後（改行を跨いでも）にある URL を同一行へ
+///   引き上げ、ナウプレ整形ハンドラを発火させて Title/Album/Artist を書き足す」
+///   正規化を持つ（handler.rb の `[[:space:]]` 引き上げ）。capsicum が既にメタを
+///   自前で出しているとこれが二重化する。URL をタグの**前**の独立行に置き、タグを
+///   末尾・後続なしにすれば引き上げ対象が無く発火しない。
+///   **URL を `#nowplaying` と同一行／直後に置かないこと。**
+/// - メタも URL も無ければ源アプリ名（"VLC で再生中" 相当をゼロにしない）、それも
+///   空なら裸のタグ。
 String formatNowPlayingFallback(NowPlayingInfo info) {
   final url = info.url;
-  final tagLine = url != null ? '$nowPlayingTag $url' : nowPlayingTag;
 
   final labeled = <String>[
     for (final (label, value) in [
@@ -50,44 +49,34 @@ String formatNowPlayingFallback(NowPlayingInfo info) {
       if (_oneLine(value).isNotEmpty) '$label: ${_oneLine(value)}',
   ];
 
-  if (labeled.isEmpty) {
-    // title/album/artist がすべて欠損。URL があればそれだけで成立する。
-    if (url != null) return tagLine;
-    // それも無ければ源アプリ名を出す（"VLC で再生中" 相当の情報をゼロにしない
-    // ため）。源アプリ名も空なら裸のタグ。
+  if (labeled.isEmpty && url == null) {
+    // title/album/artist も URL も無い。源アプリ名を出す。源アプリ名も空なら裸のタグ。
     final source = _oneLine(info.sourceAppName);
     return source.isEmpty ? nowPlayingTag : '$nowPlayingTag $source';
   }
 
-  // タグ行は末尾（上記の正規化対策）。
-  return [...labeled, tagLine].join('\n');
+  // URL は #nowplaying の前の独立行、タグは裸で末尾（上記の二重化対策）。
+  return [
+    ...labeled,
+    if (url != null) url.toString(),
+    nowPlayingTag,
+  ].join('\n');
 }
 
 /// 共有 (push) 動線の**不透明な共有テキスト**に `#nowplaying` タグを付ける (#670)。
 ///
-/// [formatNowPlayingFallback] と同じ **「タグは末尾」規律** に揃える。タグを行頭に
-/// 置くと、モロヘイヤの「`#nowplaying` 行に同一行 URL が無いと次行を詰める」正規化
-/// で、共有テキストが複数行かつ URL 無しのとき次行が詰められて結合してしまう。
-/// タグを末尾へ逃がせば詰める対象の次行が無く、副作用が出ない（formatter と同じ
-/// 理由。**先頭に戻さないこと**）。
+/// 共有はテキスト / URL を不透明に受け取るだけで曲メタ（Title/Album/Artist）を
+/// 持たないため、構造化整形はしない。共有テキストを先に置き、`#nowplaying` を
+/// **裸で末尾**に付けるだけにする（[formatNowPlayingFallback] と同じ規律に統一）。
 ///
-/// 共有テキストが単一 URL のときだけ unfurl 用にタグと同一行へ置く
-/// （`#nowplaying <url>`）。それ以外はテキストを先に、タグを末尾行に置く。
-/// 構造化整形（Title/Album/Artist 行）への完全統一は Share Extension + モロヘイヤ
-/// enrich 再設計に依存するため、本関数は **タグ配置だけ** を整える（#670 の制約）。
+/// 単一 URL でも**タグと同一行に置かない**（#727）。`#nowplaying <url>` 同一行は
+/// 本体整形とフォーマットがずれるうえ、モロヘイヤの旧ナウプレ整形ハンドラを発火
+/// させる構造になる。URL を前・タグを末尾にすれば発火せず、unfurl も従来どおり効く。
+/// URL→メタの自前補完（resolve-by-URL）は将来の上積み。
 String composeSharedNowPlaying(String sharedText) {
   final trimmed = sharedText.trim();
   if (trimmed.isEmpty) return nowPlayingTag;
-  if (_isSingleUrl(trimmed)) return '$nowPlayingTag $trimmed';
   return '$trimmed\n$nowPlayingTag';
-}
-
-/// 共有テキストが**単一 URL**（空白を含まず http(s) スキーム）か。単一 URL なら
-/// タグと同一行に置いて unfurl させられる。
-bool _isSingleUrl(String text) {
-  if (text.contains(RegExp(r'\s'))) return false;
-  final uri = Uri.tryParse(text);
-  return uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
 }
 
 /// メタデータ値を **1 行**に正規化する。前後の空白・制御文字を落とし、内部の

--- a/packages/capsicum/lib/src/util/now_playing_formatter.dart
+++ b/packages/capsicum/lib/src/util/now_playing_formatter.dart
@@ -65,18 +65,31 @@ String formatNowPlayingFallback(NowPlayingInfo info) {
 
 /// 共有 (push) 動線の**不透明な共有テキスト**に `#nowplaying` タグを付ける (#670)。
 ///
-/// 共有はテキスト / URL を不透明に受け取るだけで曲メタ（Title/Album/Artist）を
-/// 持たないため、構造化整形はしない。共有テキストを先に置き、`#nowplaying` を
-/// **裸で末尾**に付けるだけにする（[formatNowPlayingFallback] と同じ規律に統一）。
+/// **アプリ内ナウプレ（[formatNowPlayingFallback]）とは整形方針が逆**なので注意
+/// （#727）。共有は ShareExtension から **URL（または不透明テキスト）しか受け取らず**
+/// 曲メタ（Title/Album/Artist）を持たない。そのためメタはモロヘイヤの enrich に
+/// 委ねる必要があり、**単一 URL は `#nowplaying <url>` の同一行**に置いてモロヘイヤを
+/// 発火させる。アプリ内は自前メタを持つので逆に同一行を避ける（発火させると二重化）。
+/// **両者を安易に「フォーマット統一」しないこと。** 共有も自前メタで自己完結させる案
+/// （URL→メタの resolve-by-URL）は v1.38 の上積み。
 ///
-/// 単一 URL でも**タグと同一行に置かない**（#727）。`#nowplaying <url>` 同一行は
-/// 本体整形とフォーマットがずれるうえ、モロヘイヤの旧ナウプレ整形ハンドラを発火
-/// させる構造になる。URL を前・タグを末尾にすれば発火せず、unfurl も従来どおり効く。
-/// URL→メタの自前補完（resolve-by-URL）は将来の上積み。
+/// タグ自体は末尾規律に揃える。タグを行頭に置くと、モロヘイヤの「`#nowplaying` 行に
+/// 同一行 URL が無いと次行を詰める」正規化で、共有テキストが複数行かつ URL 無しのとき
+/// 次行が詰められて結合してしまう。末尾へ逃がせば詰める対象の次行が無く副作用が出ない
+/// （**先頭に戻さないこと**）。
 String composeSharedNowPlaying(String sharedText) {
   final trimmed = sharedText.trim();
   if (trimmed.isEmpty) return nowPlayingTag;
+  if (_isSingleUrl(trimmed)) return '$nowPlayingTag $trimmed';
   return '$trimmed\n$nowPlayingTag';
+}
+
+/// 共有テキストが**単一 URL**（空白を含まず http(s) スキーム）か。単一 URL なら
+/// タグと同一行に置いてモロヘイヤに enrich させられる。
+bool _isSingleUrl(String text) {
+  if (text.contains(RegExp(r'\s'))) return false;
+  final uri = Uri.tryParse(text);
+  return uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
 }
 
 /// メタデータ値を **1 行**に正規化する。前後の空白・制御文字を落とし、内部の

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.37.0+118
+version: 1.37.1+119
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.37.1+119
+version: 1.37.1+120
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum/test/now_playing_formatter_test.dart
+++ b/packages/capsicum/test/now_playing_formatter_test.dart
@@ -146,12 +146,13 @@ void main() {
 
   group('composeSharedNowPlaying', () {
     // #670: 共有(push)テキストもタグを末尾規律に揃える。
-    // 二重化対策: 単一 URL でも #nowplaying と同一行に置かない（本体整形と統一）。
+    // #727: 共有は URL しか持たずメタはモロヘイヤ enrich 任せのため、単一 URL は
+    // 同一行（発火させる）。アプリ内 formatter と方針が逆である点に注意。
 
-    test('単一 URL もテキスト先・裸タグ末尾（同一行にしない）', () {
+    test('単一 URL はタグと同一行（モロヘイヤ enrich を発火させる）', () {
       expect(
         composeSharedNowPlaying('https://music.apple.com/jp/song/1352845804'),
-        'https://music.apple.com/jp/song/1352845804\n#nowplaying',
+        '#nowplaying https://music.apple.com/jp/song/1352845804',
       );
     });
 

--- a/packages/capsicum/test/now_playing_formatter_test.dart
+++ b/packages/capsicum/test/now_playing_formatter_test.dart
@@ -2,16 +2,17 @@ import 'package:capsicum/src/util/now_playing_formatter.dart';
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// #466 capsicum 側フォールバック整形。モロヘイヤ `text_nowplaying_formatter`
-/// と揃えた複数行ラベル形式（Title/Album/Artist 行 + 末尾 `#nowplaying` 行）を
-/// 組めること、URL を持つ源は末尾タグ行に URL を載せることを確認。
+/// #466 capsicum 側整形。複数行ラベル形式（Title/Album/Artist 行 + URL 独立行 +
+/// 裸の `#nowplaying` 末尾行）を組めること、URL は **#nowplaying と同一行に置かない**
+/// ことを確認。
 ///
-/// タグ行が**末尾**なのはモロヘイヤの「`#nowplaying` 行に URL が無いと次行を
-/// 詰める」正規化対策（#466）。先頭に置くと `Title:` 行が詰められる。
+/// URL を独立行・タグを裸で末尾にするのは、モロヘイヤの「`#nowplaying` 行の直後の
+/// URL を同一行へ引き上げて整形ハンドラを再発火させ、Title/Album/Artist を二重付与
+/// する」正規化を踏ませないため（二重化対策）。
 
 void main() {
   group('formatNowPlayingFallback', () {
-    test('URL + title/album/artist はラベル行 + 末尾の URL 付きタグ行を組む', () {
+    test('URL + title/album/artist はラベル行 + URL 独立行 + 裸の末尾タグを組む', () {
       final info = NowPlayingInfo(
         sourceAppName: 'Apple Music',
         title: 'シュビドゥビ☆スイーツタイム',
@@ -24,8 +25,22 @@ void main() {
         'Title: シュビドゥビ☆スイーツタイム\n'
         'Album: スイート☆エチュード☆アラモード\n'
         'Artist: 宮本佳那子\n'
-        '#nowplaying https://music.apple.com/jp/song/1352845804',
+        'https://music.apple.com/jp/song/1352845804\n'
+        '#nowplaying',
       );
+    });
+
+    test('URL は #nowplaying と同一行に置かない（モロヘイヤ再発火による二重化防止）', () {
+      final info = NowPlayingInfo(
+        sourceAppName: 'Apple Music',
+        title: 'Song',
+        artist: 'Artist',
+        url: Uri.parse('https://open.spotify.com/track/xyz'),
+      );
+      final out = formatNowPlayingFallback(info);
+      // タグは裸で最終行。URL がタグと同一行に乗っていない。
+      expect(out.split('\n').last, nowPlayingTag);
+      expect(out, isNot(contains('$nowPlayingTag http')));
     });
 
     test('URL が無い源（SMTC / MPRIS）は Title/Album/Artist 行 + 末尾タグ', () {
@@ -90,14 +105,14 @@ void main() {
       expect(formatNowPlayingFallback(info), '#nowplaying');
     });
 
-    test('URL があれば title/artist が空でも URL 行のみで成立', () {
+    test('URL があれば title/artist が空でも URL 独立行 + 末尾タグで成立', () {
       final info = NowPlayingInfo(
         sourceAppName: 'Spotify',
         url: Uri.parse('https://open.spotify.com/track/xyz'),
       );
       expect(
         formatNowPlayingFallback(info),
-        '#nowplaying https://open.spotify.com/track/xyz',
+        'https://open.spotify.com/track/xyz\n#nowplaying',
       );
     });
 
@@ -131,11 +146,12 @@ void main() {
 
   group('composeSharedNowPlaying', () {
     // #670: 共有(push)テキストもタグを末尾規律に揃える。
+    // 二重化対策: 単一 URL でも #nowplaying と同一行に置かない（本体整形と統一）。
 
-    test('単一 URL はタグと同一行（unfurl 用）', () {
+    test('単一 URL もテキスト先・裸タグ末尾（同一行にしない）', () {
       expect(
         composeSharedNowPlaying('https://music.apple.com/jp/song/1352845804'),
-        '#nowplaying https://music.apple.com/jp/song/1352845804',
+        'https://music.apple.com/jp/song/1352845804\n#nowplaying',
       );
     });
 


### PR DESCRIPTION
v1.37 で出荷したアプリ内ナウプレ（+enrich）で、Title/Album/Artist が二重化する不具合のホットフィックス。

- 根因: capsicum が `#nowplaying <url>` を同一行で出し、モロヘイヤ旧ナウプレ整形ハンドラ（handler.rb:216 の `[[:space:]]` 引き上げ → NowplayingHandler 発火）が Title/Album/Artist を再付与していた。
- 修正: URL を `#nowplaying` の前の独立行に出し、タグは裸で末尾に固定。共有経路もフォーマットを統一。モロヘイヤのハンドラ ON/OFF いずれでも二重化しない。
- 1.37.0+118 → 1.37.1+119。テスト 19/19 緑、format/analyze クリーン。

詳細・経緯: #727