### PR TITLE
v1.42.1: ストリーミング無音切断の検知（WS ping/pong）ホットフィックス

### DIFF
--- a/capsicum.code-workspace
+++ b/capsicum.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../capsicum-relay"
+		}
+	],
+	"settings": {}
+}

--- a/docs/store-release-guide.md
+++ b/docs/store-release-guide.md
@@ -334,6 +334,55 @@ cd ..
 > **macOS の `.pkg` 生成が iOS と異なる理由:**
 > iOS は `flutter build ipa --release` 一発で App Store 提出可能な ipa が出来るが、macOS の `flutter build macos --release` は Apple Development 証明書 + Mac App Development profile を埋め込んだ `.app` を出力するだけで、Mac App Store には提出できない。`xcodebuild archive` + `-exportArchive` を経由することで Apple Distribution + Mac App Store profile + 3rd Party Mac Developer Installer による `.pkg` 署名が automatic に行われる。`flutter build macos` を先に走らせるのは Generated.xcconfig の `DART_DEFINES` を更新するため（archive 単独では `--dart-define` を渡せない）。
 
+#### Android: 16KB ページサイズ対応（必須・irondash をローカルビルド）
+
+Google Play は **64bit ネイティブ `.so` の LOAD セグメントが 16KB 整列**（`p_align >= 16384`）でないと製品版昇格を `Artifact does not support 16KB page size` で拒否する（2026-06 にハード強制が有効化。それ以前は警告だったため v1.41.1 までは 4KB のまま production に出ていた）。
+
+問題のライブラリは `irondash_engine_context`（`super_drag_and_drop` → `super_native_extensions` の transitive 依存）。cargokit はデフォルトで **GitHub の precompiled `.so` をダウンロード**して使うが、irondash 0.5.5（最新）の precompiled は 4KB 整列で upstream に修正版がない（姉妹の super_native_extensions は precompiled が 16KB 済み）。precompiled は再整列できないため、**ローカル Rust ビルドに切り替えて 16KB リンカフラグを注入**する。
+
+恒久設定（コミット済み）: [`packages/capsicum/android/cargokit_options.yaml`](../packages/capsicum/android/cargokit_options.yaml) に `use_precompiled_binaries: false`。これで cargokit は irondash / super_native_extensions をローカルビルドする。
+
+**Android ビルドマシンの前提**: rustup + android ターゲットが必要（cargokit は rustup 不在だと precompiled に戻る）。
+
+```bash
+# 一度だけ（rustup 未導入のマシン）
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+export PATH="$HOME/.cargo/bin:$PATH"
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+```
+
+`flutter build appbundle` を走らせる際、§4.2 の手順に加えて **リンカフラグを export し、stale な gradle daemon を止める**（daemon が古い環境を握っていると cargokit にフラグが渡らず 4KB のままになる。一度これで踏んだ）:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"          # rustup を PATH に
+export CARGO_ENCODED_RUSTFLAGS='-Clink-arg=-Wl,-z,max-page-size=16384'
+( cd android && ./gradlew --stop )            # 古い daemon を破棄（新 daemon に env を継承させる）
+flutter clean && flutter pub get
+# …§4.2 の flutter build appbundle …
+```
+
+**アップロード前に必ず整列を検証する**（フラグが silent に効かないことがあるため必須ゲート）:
+
+```bash
+cd packages/capsicum
+unzip -o build/app/outputs/bundle/release/app-release.aab 'base/lib/arm64-v8a/*.so' -d /tmp/so >/dev/null
+# 各 .so の PT_LOAD p_align が 16384 以上であること（特に libirondash_engine_context_native.so）
+for f in /tmp/so/base/lib/arm64-v8a/*.so; do
+  printf '%s ' "$(basename "$f")"
+  python3 - "$f" <<'PY'
+import sys,struct
+d=open(sys.argv[1],'rb').read(); off=struct.unpack_from('<Q',d,0x20)[0]
+es=struct.unpack_from('<H',d,0x36)[0]; n=struct.unpack_from('<H',d,0x38)[0]; m=0
+for i in range(n):
+    o=off+i*es
+    if struct.unpack_from('<I',d,o)[0]==1: m=max(m,struct.unpack_from('<Q',d,o+0x30)[0])
+print('align',m,'OK' if m>=16384 else 'BAD')
+PY
+done
+```
+
+`libirondash_engine_context_native.so` が `BAD align=4096` なら、上の export / daemon 停止が効いていない。直してから upload すること。
+
 ### 4.3 製品版昇格・審査提出
 
 #### ストア掲載文の見直し要否（提出前に必ず判断する）

--- a/docs/tech-notes.md
+++ b/docs/tech-notes.md
@@ -50,6 +50,12 @@ Google Play は 64bit `.so` の LOAD セグメントが 16KB 整列（`p_align >
 - **Misskey**: `reconnecting-websocket`（バックオフ付き自動再接続、misskey-js `streaming.ts`）。再接続時はチャンネルを張り直すのみで、切断中のギャップを能動回収はしない（realtime は prepend 任せ・非 realtime は `fetchNewer` ポーリング）。
 - **capsicum**: live 復帰時に since までさかのぼって REST 差分を能動回収（`collectCatchUpGap`）。取りこぼし対策はむしろ両本家より手厚い。#784/#782 の方向性が正しかったことの裏取りにもなった。
 
+### `WebSocketChannel.connect` には liveness が無い — 無音切断検知には `pingInterval` 必須（#788）
+
+`web_socket_channel` の `WebSocketChannel.connect(uri)` を引数なしで張ると ping/pong を一切送らない。無音切断（NAT/プロキシのアイドル切断・モバイル回線・サーバーの ungraceful な離脱）では TCP に FIN/RST が来ず、`onDone`/`onError` が発火しないため、capsicum は「繋がっているつもり」で死んだソケットに座り続け **再接続トリガー自体が引かれない**。バックオフをいくら粘らせても、検知が無ければ復帰しない（#784/#782 は「検知後」の層なので無音切断には効かない）。
+
+対処は `IOWebSocketChannel.connect(uri, pingInterval: ...)`。dart:io が `pingInterval` ごとに WS ping を送り、同間隔内に pong が無ければ自動で close → `onDone` 発火 → 既存の再接続ロジックが動く。検知時間 ≒ `pingInterval`。本家 Misskey WebUI が「頻繁に再接続している」のはこの検知が効いて素早く復帰しているからで、頻度の高さは弱点ではない。capsicum は timeline=30s / notification・chat=60s で設定（Mastodon/Misskey 両プロトコル共通の欠落だったため両方に入れた）。`pingInterval` は dart:io 由来で web では使えないが、capsicum は web を出荷対象にしていないため `IOWebSocketChannel` 直叩きで問題ない。md.korako.me（Mastodon）と きゅあすきー（Misskey）の両方で「再接続できない」が同時報告されたのが発見の端緒（karasu_sue 報告）。
+
 ## デスクトップ（drag & drop / ネイティブ連携）
 
 ### drag-out の重い処理（ダウンロード等）は `dragItemProvider` ではなく virtual file provider に置く

--- a/docs/tech-notes.md
+++ b/docs/tech-notes.md
@@ -32,6 +32,14 @@ MFM のリンク記法 `[text](URL)` は、現状の正規表現ベースの URL
 
 capsicum の依存は `^` 制約の浮動指定で `pubspec.lock` も `.gitignore` 対象のため、CI は毎回最新版を解決する。外部パッケージが enum に値を足すと、`default:` の無い網羅 switch が `non_exhaustive_switch_statement` でコンパイル不能になり、**ソース無変更のまま CI が突然全滅する**（手元は旧 lock を握っていて再現しない）。v1.42 で dio 5.10.0 の `DioExceptionType.transformTimeout` 追加により `push_relay_client.dart` の網羅 switch が落ち、develop の Analyze / Linux / Windows Release が全滅した。**外部パッケージの enum を switch するときは必ず `default:` を置く**（前方互換）。ローカル analyze が通っても CI と dio 解決バージョンがズレている可能性があるので、CI 失敗時はまず `dart pub upgrade <pkg>` で最新解決に揃えて再現確認する。
 
+### Android 16KB ページサイズ：irondash の precompiled `.so` が 4KB で Play に弾かれる
+
+Google Play は 64bit `.so` の LOAD セグメントが 16KB 整列（`p_align >= 16384`）でないと製品版昇格を `Artifact does not support 16KB page size` で拒否する（2026-06 にハード強制が有効化。それ以前は警告で、同じ 4KB バイナリのまま production に出ていた＝我々の回帰ではなくストア側の締め付け）。v1.42 build 138 で踏んだ。
+
+原因は `irondash_engine_context`（`super_drag_and_drop` → `super_native_extensions` の transitive 依存）。cargokit はデフォルトで **GitHub の precompiled `.so` をダウンロード**して使い、irondash 0.5.5（最新）の precompiled が 4KB 整列・upstream 修正なし（姉妹 super_native_extensions は build.rs に `cargo:rustc-link-arg=-Wl,-z,max-page-size=16384` があり precompiled も 16KB 済み）。**ELF セグメント整列は後から変えられない**ので zipalign 等では直らない。
+
+対処（恒久・コミット済み）: `packages/capsicum/android/cargokit_options.yaml` に `use_precompiled_binaries: false` を置いてローカル Rust ビルドへ切り替え（要 rustup + android ターゲット）、ビルド時に `CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-Wl,-z,max-page-size=16384` を渡して 16KB 整列させる。**stale な gradle daemon は古い環境を握っていてフラグを取りこぼす**ので `./gradlew --stop` してから build。手順・検証の正本は docs/store-release-guide.md §4.2「Android: 16KB ページサイズ対応」。アップロード前に `.so` の `p_align` を必ず検証する。
+
 ### 仕様に迷ったらまず本家 Mastodon / Misskey の実装を確認する
 
 ストリーミング・ページネーション・通知など、SNS の挙動に関わる設計判断で迷ったら、推測する前に本家 WebUI の実装を読む癖をつける。手元のフォーク（`~/repos/mastodon` = bshockdon / `~/repos/misskey` = daisskey）に上流コードが入っており、`git fetch` で最新化して確認できる（[server-forks の経緯はメモリ参照]）。capsicum の方が手厚いこともあれば、本家の方が枯れていて正しいこともあるので、まず一次情報を当たる。

--- a/packages/capsicum/android/cargokit_options.yaml
+++ b/packages/capsicum/android/cargokit_options.yaml
@@ -1,0 +1,8 @@
+# irondash_engine_context 0.5.5 が配布する precompiled な Android .so は
+# 16KB ページサイズ非対応（LOAD セグメントが 4KB 整列）で、Google Play の
+# 製品版昇格が "Artifact does not support 16KB page size" で弾かれる。
+# precompiled を使わずローカル Rust ビルドに切り替え、ビルド時に
+# CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-Wl,-z,max-page-size=16384 を渡して
+# 16KB 整列させる（docs/store-release-guide.md §4.2 / docs/tech-notes.md 参照）。
+# ローカルビルドには rustup + android ターゲットが必要。
+use_precompiled_binaries: false

--- a/packages/capsicum/lib/src/provider/timeline_provider.dart
+++ b/packages/capsicum/lib/src/provider/timeline_provider.dart
@@ -564,6 +564,9 @@ class TimelineNotifier extends AutoDisposeAsyncNotifier<TimelineState> {
   DateTime? _lastParseCapture;
   DateTime? _lastConnectCapture;
   DateTime? _lastListenCapture;
+  // 切断 (onDone) の closeCode 観測用バケット (#788)。性質が違うので
+  // connect/parse/listen とは独立に持つ。
+  DateTime? _lastDisconnectCapture;
   static const _captureThrottle = Duration(seconds: 60);
 
   void _startStreaming(StreamSupport adapter, TimelineType type) {
@@ -677,6 +680,33 @@ class TimelineNotifier extends AutoDisposeAsyncNotifier<TimelineState> {
                 ? false
                 : null,
           ),
+        );
+      },
+      // 「どんな切れ方をしているか」を本番で観測する (#788)。現象すら未把握な
+      // ので原因対処はせず計器のみ。closeCode 分布 (1000 正常 / 1001 ping
+      // タイムアウト goingAway / 1006 異常 …) で正体に近づく。host 分岐は入れ
+      // ない (全サーバー共通)。closeReason はサーバー任意文字列を持ちうるため
+      // 内容は載せず、有無のみ。throttle で切断連発の spam を抑える。
+      onDisconnect: (closeCode, closeReason) {
+        final now = DateTime.now();
+        if (_lastDisconnectCapture != null &&
+            now.difference(_lastDisconnectCapture!) < _captureThrottle) {
+          return;
+        }
+        _lastDisconnectCapture = now;
+        final code = closeCode?.toString() ?? 'none';
+        Sentry.captureMessage(
+          'timeline.stream.disconnected',
+          level: SentryLevel.info,
+          withScope: (scope) {
+            scope.setTag('timeline.stream', 'disconnected');
+            scope.setTag('timeline.stream.close_code', code);
+            scope.setTag(
+              'timeline.stream.has_reason',
+              (closeReason != null && closeReason.isNotEmpty).toString(),
+            );
+            scope.fingerprint = ['timeline.stream.disconnected', code];
+          },
         );
       },
     );

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.42.0+138
+version: 1.42.1+139
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.42.1+139
+version: 1.42.1+140
 
 environment:
   sdk: ^3.11.0

--- a/packages/capsicum_backends/lib/src/mastodon/adapter.dart
+++ b/packages/capsicum_backends/lib/src/mastodon/adapter.dart
@@ -1001,6 +1001,7 @@ class MastodonAdapter extends DecentralizedBackendAdapter
     void Function(Object error, StackTrace stack)? onStreamError,
     void Function()? onReconnectExhausted,
     void Function(StreamConnectionState state)? onConnectionState,
+    void Function(int? closeCode, String? closeReason)? onDisconnect,
   }) {
     _streaming?.dispose();
     // DM timeline has no dedicated stream; avoid falling back to 'user'
@@ -1016,6 +1017,7 @@ class MastodonAdapter extends DecentralizedBackendAdapter
       onStreamError: onStreamError,
       onReconnectExhausted: onReconnectExhausted,
       onConnectionState: onConnectionState,
+      onDisconnect: onDisconnect,
     );
     return _streaming!.connect(type);
   }

--- a/packages/capsicum_backends/lib/src/mastodon/notification_streaming.dart
+++ b/packages/capsicum_backends/lib/src/mastodon/notification_streaming.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:fediverse_objects/fediverse_objects.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'extensions.dart';
@@ -31,6 +32,9 @@ class MastodonNotificationStreaming {
   static const _maxReconnectAttempts = 10;
   static const _baseReconnectDelay = Duration(seconds: 5);
   static const _maxReconnectDelay = Duration(seconds: 300);
+  // 無音切断を検知するための WS ping/pong。pong が無ければ自動 close → onDone →
+  // 再接続が走る (#788)。通知は緊急性が低めなので timeline より長め。
+  static const _pingInterval = Duration(seconds: 60);
 
   MastodonNotificationStreaming({
     required this.host,
@@ -59,7 +63,7 @@ class MastodonNotificationStreaming {
       queryParameters: {'access_token': accessToken, 'stream': 'user'},
     );
 
-    _channel = WebSocketChannel.connect(uri);
+    _channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
     _channel!.ready
         .then((_) {
           _reconnectAttempts = 0;

--- a/packages/capsicum_backends/lib/src/mastodon/streaming.dart
+++ b/packages/capsicum_backends/lib/src/mastodon/streaming.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:fediverse_objects/fediverse_objects.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../streaming_backoff.dart';
@@ -48,6 +49,13 @@ class MastodonStreaming {
   // 短め（5 分待ちは実況で長すぎる）。jitter は streaming_backoff 側で付与 (#784)。
   static const _baseReconnectDelay = Duration(seconds: 1);
   static const _maxReconnectDelay = Duration(seconds: 60);
+  // 無音切断（NAT/プロキシのアイドル切断・ungraceful な離脱）では FIN/RST が
+  // 来ず onDone/onError が発火しないため、ping/pong を張らないと「繋がっている
+  // つもり」で死んだソケットに座り続け再接続が走らない (#788)。pingInterval を
+  // 設定すると dart:io が ping を送り、同間隔内に pong が無ければ自動で close →
+  // onDone 発火 → 既存の再接続ロジックが動く。検知時間 ≒ pingInterval。本線
+  // タイムラインは即時性が要るので短め。
+  static const _pingInterval = Duration(seconds: 30);
 
   MastodonStreaming({
     required this.host,
@@ -90,7 +98,7 @@ class MastodonStreaming {
       queryParameters: {'access_token': accessToken, 'stream': stream},
     );
 
-    _channel = WebSocketChannel.connect(uri);
+    _channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
     _channel!.ready
         .then((_) {
           _reconnectAttempts = 0;

--- a/packages/capsicum_backends/lib/src/mastodon/streaming.dart
+++ b/packages/capsicum_backends/lib/src/mastodon/streaming.dart
@@ -34,6 +34,13 @@ class MastodonStreaming {
   /// 接続ライフサイクルの遷移を呼び出し側 (UI インジケータ) へ流す (#714)。
   final void Function(StreamConnectionState state)? onConnectionState;
 
+  /// 切断 (onDone) 時の WebSocket closeCode / closeReason を観測層へ流す (#788)。
+  /// 無音切断の検知層 (pingInterval) を入れた今、本番で「どんな切れ方をして
+  /// いるか」(1000 正常 / 1001 ping タイムアウト goingAway / 1006 異常 …) を
+  /// Sentry で見るための計装。現象すら未把握なので原因対処はせず計器のみ。
+  /// null なら無視。
+  final void Function(int? closeCode, String? closeReason)? onDisconnect;
+
   WebSocketChannel? _channel;
   StreamController<Post>? _controller;
   Timer? _reconnectTimer;
@@ -65,6 +72,7 @@ class MastodonStreaming {
     this.onStreamError,
     this.onReconnectExhausted,
     this.onConnectionState,
+    this.onDisconnect,
   });
 
   // 同じ状態が連続するときは UI へ重複通知しない (#714)。観測経路の失敗で
@@ -123,6 +131,7 @@ class MastodonStreaming {
         // 上限到達による `onReconnectExhausted` 通知も出なくなる。リセット
         // は `ready.then` の接続成功時のみ行い、DM (`chat_streaming.dart`) /
         // ルーム (`chat_room_streaming.dart`) と挙動を揃える。
+        _notifyDisconnect();
         _notifyConnectionState(StreamConnectionState.disconnected);
         _scheduleReconnect();
       },
@@ -135,6 +144,14 @@ class MastodonStreaming {
     } catch (_) {
       // 観測経路の失敗で本筋を止めない。
     }
+  }
+
+  // onDone 時の closeCode/closeReason を観測層へ。閉じた直後なので channel に
+  // closeCode が乗っている。観測経路の失敗で本筋を止めない (#788)。
+  void _notifyDisconnect() {
+    try {
+      onDisconnect?.call(_channel?.closeCode, _channel?.closeReason);
+    } catch (_) {}
   }
 
   void _onMessage(dynamic message) {

--- a/packages/capsicum_backends/lib/src/misskey/adapter.dart
+++ b/packages/capsicum_backends/lib/src/misskey/adapter.dart
@@ -1388,6 +1388,7 @@ class MisskeyAdapter extends DecentralizedBackendAdapter
     void Function(Object error, StackTrace stack)? onStreamError,
     void Function()? onReconnectExhausted,
     void Function(StreamConnectionState state)? onConnectionState,
+    void Function(int? closeCode, String? closeReason)? onDisconnect,
   }) {
     _streaming?.dispose();
     final token = client.accessToken;
@@ -1400,6 +1401,7 @@ class MisskeyAdapter extends DecentralizedBackendAdapter
       onStreamError: onStreamError,
       onReconnectExhausted: onReconnectExhausted,
       onConnectionState: onConnectionState,
+      onDisconnect: onDisconnect,
     );
     return _streaming!.connect(type).map(_applyWordFilter);
   }

--- a/packages/capsicum_backends/lib/src/misskey/chat_streaming_base.dart
+++ b/packages/capsicum_backends/lib/src/misskey/chat_streaming_base.dart
@@ -74,7 +74,10 @@ abstract class MisskeyChatStreamingBase {
       queryParameters: {'i': accessToken},
     );
 
-    final channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
+    final channel = IOWebSocketChannel.connect(
+      uri,
+      pingInterval: _pingInterval,
+    );
     _channel = channel;
     // listener / catchError は前世代 channel の close でも発火しうるので
     // 「現役 channel と同一か」をクロージャ捕捉した channel で判定し、旧世代の

--- a/packages/capsicum_backends/lib/src/misskey/chat_streaming_base.dart
+++ b/packages/capsicum_backends/lib/src/misskey/chat_streaming_base.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:uuid/uuid.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Misskey の `/streaming` WebSocket を 1 本張り、指数バックオフ再接続つきで
@@ -32,6 +33,9 @@ abstract class MisskeyChatStreamingBase {
   static const _maxReconnectAttempts = 10;
   static const _baseReconnectDelay = Duration(seconds: 5);
   static const _maxReconnectDelay = Duration(seconds: 300);
+  // 無音切断を検知するための WS ping/pong。pong が無ければ自動 close → onDone →
+  // 再接続が走る (#788)。チャットは緊急性が低めなので timeline より長め。
+  static const _pingInterval = Duration(seconds: 60);
 
   MisskeyChatStreamingBase({
     required this.host,
@@ -70,7 +74,7 @@ abstract class MisskeyChatStreamingBase {
       queryParameters: {'i': accessToken},
     );
 
-    final channel = WebSocketChannel.connect(uri);
+    final channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
     _channel = channel;
     // listener / catchError は前世代 channel の close でも発火しうるので
     // 「現役 channel と同一か」をクロージャ捕捉した channel で判定し、旧世代の

--- a/packages/capsicum_backends/lib/src/misskey/notification_streaming.dart
+++ b/packages/capsicum_backends/lib/src/misskey/notification_streaming.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:fediverse_objects/fediverse_objects.dart';
 import 'package:uuid/uuid.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'extensions.dart';
@@ -32,6 +33,9 @@ class MisskeyNotificationStreaming {
   static const _maxReconnectAttempts = 10;
   static const _baseReconnectDelay = Duration(seconds: 5);
   static const _maxReconnectDelay = Duration(seconds: 300);
+  // 無音切断を検知するための WS ping/pong。pong が無ければ自動 close → onDone →
+  // 再接続が走る (#788)。通知は緊急性が低めなので timeline より長め。
+  static const _pingInterval = Duration(seconds: 60);
 
   MisskeyNotificationStreaming({
     required this.host,
@@ -60,7 +64,7 @@ class MisskeyNotificationStreaming {
       queryParameters: {'i': accessToken},
     );
 
-    _channel = WebSocketChannel.connect(uri);
+    _channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
     _channel!.stream.listen(
       _onMessage,
       onError: (Object error, StackTrace stack) {

--- a/packages/capsicum_backends/lib/src/misskey/streaming.dart
+++ b/packages/capsicum_backends/lib/src/misskey/streaming.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:fediverse_objects/fediverse_objects.dart';
 import 'package:uuid/uuid.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../streaming_backoff.dart';
@@ -47,6 +48,9 @@ class MisskeyStreaming {
   // 短め。jitter は streaming_backoff 側で付与 (#784)。
   static const _baseReconnectDelay = Duration(seconds: 1);
   static const _maxReconnectDelay = Duration(seconds: 60);
+  // 無音切断を検知するための WS ping/pong。pong が無ければ自動 close → onDone →
+  // 再接続が走る (#788)。本線タイムラインは即時性が要るので短め。
+  static const _pingInterval = Duration(seconds: 30);
 
   MisskeyStreaming({
     required this.host,
@@ -88,7 +92,7 @@ class MisskeyStreaming {
       queryParameters: {'i': accessToken},
     );
 
-    _channel = WebSocketChannel.connect(uri);
+    _channel = IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
     _channel!.stream.listen(
       _onMessage,
       onError: (Object error, StackTrace stack) {

--- a/packages/capsicum_backends/lib/src/misskey/streaming.dart
+++ b/packages/capsicum_backends/lib/src/misskey/streaming.dart
@@ -32,6 +32,13 @@ class MisskeyStreaming {
   /// 接続ライフサイクルの遷移を呼び出し側 (UI インジケータ) へ流す (#714)。
   final void Function(StreamConnectionState state)? onConnectionState;
 
+  /// 切断 (onDone) 時の WebSocket closeCode / closeReason を観測層へ流す (#788)。
+  /// 無音切断の検知層 (pingInterval) を入れた今、本番で「どんな切れ方をして
+  /// いるか」(1000 正常 / 1001 ping タイムアウト goingAway / 1006 異常 …) を
+  /// Sentry で見るための計装。現象すら未把握なので原因対処はせず計器のみ。
+  /// null なら無視。
+  final void Function(int? closeCode, String? closeReason)? onDisconnect;
+
   WebSocketChannel? _channel;
   StreamController<Post>? _controller;
   Timer? _reconnectTimer;
@@ -60,6 +67,7 @@ class MisskeyStreaming {
     this.onStreamError,
     this.onReconnectExhausted,
     this.onConnectionState,
+    this.onDisconnect,
   });
 
   // 同じ状態が連続するときは UI へ重複通知しない (#714)。観測経路の失敗で
@@ -105,6 +113,7 @@ class MisskeyStreaming {
         // onDone→reset」のループでバックオフが基底値のまま動かず、上限到達に
         // よる `onReconnectExhausted` 通知も出なくなる。リセットは接続成功
         // (`ready.then`) 時のみに揃える（Mastodon 側 streaming.dart と同挙動）。
+        _notifyDisconnect();
         _notifyConnectionState(StreamConnectionState.disconnected);
         _scheduleReconnect();
       },
@@ -133,6 +142,14 @@ class MisskeyStreaming {
           _notifyConnectionState(StreamConnectionState.disconnected);
           _scheduleReconnect();
         });
+  }
+
+  // onDone 時の closeCode/closeReason を観測層へ。閉じた直後なので channel に
+  // closeCode が乗っている。観測経路の失敗で本筋を止めない (#788)。
+  void _notifyDisconnect() {
+    try {
+      onDisconnect?.call(_channel?.closeCode, _channel?.closeReason);
+    } catch (_) {}
   }
 
   void _notifyStreamError(Object error, StackTrace stack) {

--- a/packages/capsicum_core/lib/src/social/interfaces/stream_support.dart
+++ b/packages/capsicum_core/lib/src/social/interfaces/stream_support.dart
@@ -18,12 +18,17 @@ abstract mixin class StreamSupport {
   /// [onConnectionState] は接続ライフサイクル (connecting / live / disconnected
   /// / exhausted) の遷移ごとに呼ばれる。常時の接続インジケータを出す用途を
   /// 想定 (#714)。同じ状態が連続するときは重複通知しない。
+  ///
+  /// [onDisconnect] は WebSocket が onDone で閉じたときに closeCode / closeReason
+  /// とともに呼ばれる。本番でどんな切れ方をしているか (1000 / 1001 / 1006 …) を
+  /// Sentry で観測する用途を想定 (#788)。null なら無視。
   Stream<Post> streamTimeline(
     TimelineType type, {
     void Function(Object error, StackTrace stack)? onParseError,
     void Function(Object error, StackTrace stack)? onStreamError,
     void Function()? onReconnectExhausted,
     void Function(StreamConnectionState state)? onConnectionState,
+    void Function(int? closeCode, String? closeReason)? onDisconnect,
   });
 
   /// Closes the current streaming connection.


### PR DESCRIPTION
v1.42.0 後のホットフィックス（大更新なし）。#788。

## 背景
karasu_sue 氏報告：md.korako.me（Mastodon）と きゅあすきー（Misskey）の両プロトコルで「切れて再接続できない」。ただし **pooza 環境では再現せず、原因どころか「どんな現象が起きているか」すら未把握**。きゅあすきーの「数分ごとに頻繁に切れる」問題自体は別途解決済みで、残るのは 20:06 の「切れて戻らない」系。

## 1. 無音切断の検知層を入れる（fix）
全ストリーミング接続が `WebSocketChannel.connect(uri)` を引数なしで張り ping/pong が無かった。無音切断（NAT/プロキシのアイドル切断・ungraceful な離脱）では FIN/RST が来ず `onDone`/`onError` が発火せず、死んだソケットに座り続けて再接続トリガーが引かれない。`IOWebSocketChannel.connect(uri, pingInterval:)` に差し替え（timeline=30s・notification/chat=60s、Mastodon/Misskey 両対応）。pong が無ければ自動 close → onDone → 既存再接続が動く。

## 2. 切れ方を本番で観測する（feat・計装）
現象すら未把握なので、timeline streaming の onDone 時に closeCode/closeReason を Sentry tag 化（`close_code`: 1000/1001/1006 …）。closeReason は内容を載せず有無のみ。host 非分岐・throttle 付き。1001(goingAway) 起点の再接続が立てば pingInterval が無音切断を捕まえている裏取りにもなる。

## 検証方針
**pooza 環境で再現しないため再現検証は行わない**（[検証困難なバグは動作確認なしで可]）。効果と現象は**本番 Sentry の close_code 分布で回収**する。

## 同梱
Android 16KB ページサイズ対応（v1.42.0 で踏んだ irondash precompiled .so の 4KB 整列問題の恒久対応）を cherry-pick。

## 検証済み
`flutter analyze` クリーン・既存ストリーミング/timeline テスト全合格。build 140。