### PR TITLE
v1.49.1 ホットフィックス（Linux 半角数字の幅崩れ #869）

### DIFF
--- a/packages/capsicum/lib/main.dart
+++ b/packages/capsicum/lib/main.dart
@@ -65,6 +65,12 @@ const _snackBarTheme = SnackBarThemeData(
 /// カラー絵文字フォントを名指しして順位付けを迂回する。ファミリ名で system
 /// フォントを引くだけなので容量増はなく、当該ファミリを持たない他プラット
 /// フォームでは素通りして OS 側の (既に正常な) 解決がそのまま効く。
+///
+/// ただし Noto Color Emoji はキーキャップ絵文字の土台として ASCII 数字
+/// `0-9` `#` `*` のグリフを持つため、Linux では半角数字までカラーフォントに
+/// 横取りされて幅が崩れる (#869)。Linux ではこの適用を
+/// [colorEmojiFallbackProvider] でトグルできるようにし、OFF でこの const を
+/// 外す (build 内で解決)。他 OS は従来どおり無条件適用。
 const _fontFamilyFallback = <String>['Noto Color Emoji'];
 
 /// debug ビルドでのみ debugPrint に流す。release ビルドでは no-op (#512)。
@@ -1220,6 +1226,14 @@ class _CapsicumAppState extends ConsumerState<CapsicumApp>
     final darkTextVariant = ref.watch(darkTextColorProvider);
     final darkText = darkTextColor(darkTextVariant);
 
+    // カラー絵文字フォールバック (#861) の適用。Linux でトグル OFF のときのみ
+    // 外して #861 以前の挙動 (半角数字の幅が正しい) に戻す (#869)。他 OS は
+    // 従来どおり無条件に適用し、既存挙動を一切変えない。
+    final fontFamilyFallback =
+        colorEmojiFallbackConfigurable && !ref.watch(colorEmojiFallbackProvider)
+        ? null
+        : _fontFamilyFallback;
+
     var darkScheme = ColorScheme.fromSeed(
       seedColor: seedColor,
       brightness: Brightness.dark,
@@ -1255,13 +1269,13 @@ class _CapsicumAppState extends ConsumerState<CapsicumApp>
         colorScheme: ColorScheme.fromSeed(seedColor: seedColor),
         useMaterial3: true,
         snackBarTheme: _snackBarTheme,
-        fontFamilyFallback: _fontFamilyFallback,
+        fontFamilyFallback: fontFamilyFallback,
       ),
       darkTheme: ThemeData(
         colorScheme: darkScheme,
         useMaterial3: true,
         snackBarTheme: _snackBarTheme,
-        fontFamilyFallback: _fontFamilyFallback,
+        fontFamilyFallback: fontFamilyFallback,
       ),
       themeMode: themeMode,
       builder: (context, child) {

--- a/packages/capsicum/lib/src/platform/platform_info.dart
+++ b/packages/capsicum/lib/src/platform/platform_info.dart
@@ -11,6 +11,15 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 bool get isDesktop =>
     !kIsWeb && (Platform.isMacOS || Platform.isWindows || Platform.isLinux);
 
+/// カラー絵文字フォールバック (#861) の ON/OFF トグルを設定に出すか。
+/// この設定が意味を持つのは Linux のみ。#861 は `Noto Color Emoji` を
+/// グローバルな fontFamilyFallback に足す対処で、Linux では同フォントが
+/// ASCII 数字グリフまで横取りして半角数字の幅が崩れる回帰 (#869) を生む。
+/// 他 OS は OS 側の絵文字解決が既に正しく、この対処自体が実質 no-op のため
+/// トグルを出さない。UI 層に `Platform.isX` を直書きしない設計指針 (#650) に
+/// 従い機能名で公開する。
+bool get colorEmojiFallbackConfigurable => !kIsWeb && Platform.isLinux;
+
 /// 常駐モード (#752) の常駐先の OS 別呼称。macOS は「メニューバー」
 /// （NSStatusItem）、Windows / Linux は「トレイ」。設定画面の説明文を OS に
 /// 合わせて出し分けるために機能名で公開する（UI 層に `Platform.isX` を直書き

--- a/packages/capsicum/lib/src/provider/preferences_provider.dart
+++ b/packages/capsicum/lib/src/provider/preferences_provider.dart
@@ -50,6 +50,7 @@ const _launchAtLoginKey = 'launch_at_login';
 const _postTouchActionsKey = 'post_touch_actions';
 const _nowPlayingUrlProviderKey = 'nowplaying_url_provider';
 const _showStreamReconnectDetailKey = 'show_stream_reconnect_detail';
+const _colorEmojiFallbackKey = 'color_emoji_fallback';
 
 /// Display mode for OGP preview cards.
 enum PreviewCardMode {
@@ -932,6 +933,37 @@ class ShowStreamReconnectDetailNotifier extends Notifier<bool> {
     state = value;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_showStreamReconnectDetailKey, value);
+  }
+}
+
+/// Linux でカラー絵文字フォールバック (`Noto Color Emoji` を fontFamilyFallback
+/// に足す #861 の対処) を効かせるか。default ON。
+///
+/// #861 の対処はグローバルに `Noto Color Emoji` を足すため、同フォントが
+/// キーキャップ絵文字 (0️⃣〜9️⃣) の土台として持つ ASCII 数字 `0-9` `#` `*` の
+/// グリフまで横取りし、半角数字が絵文字メトリクス (ほぼ全角幅) で描かれて
+/// 全画面で幅が崩れる回帰 (#869) を生む。OFF にすると #861 以前の挙動
+/// (数字は正しいが一部 Unicode 絵文字はモノクロ) に戻せる。カラー絵文字と
+/// 数字の正しさを両立させる洗練は別途 (#869 参照)。
+///
+/// theme (MaterialApp) に効くため、起動直後の一瞬のちらつきを避けるべく
+/// pre-warm 済み prefs から同期ロードする (`residentModeProvider` 等と同型)。
+final colorEmojiFallbackProvider =
+    NotifierProvider<ColorEmojiFallbackNotifier, bool>(
+      ColorEmojiFallbackNotifier.new,
+    );
+
+class ColorEmojiFallbackNotifier extends Notifier<bool> {
+  @override
+  bool build() {
+    return sharedPrefsOrThrow.getBool(_colorEmojiFallbackKey) ?? true;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    if (state == value) return;
+    state = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_colorEmojiFallbackKey, value);
   }
 }
 

--- a/packages/capsicum/lib/src/ui/screen/settings/desktop_settings_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/desktop_settings_screen.dart
@@ -72,23 +72,6 @@ class DesktopSettingsScreen extends ConsumerWidget {
               onChanged: (value) =>
                   ref.read(launchAtLoginProvider.notifier).setEnabled(value),
             ),
-          // カラー絵文字フォールバック (#861 / #869)。Linux のみ意味がある。
-          // ON (既定) は #861 の対処で Unicode 絵文字をカラー表示するが、その
-          // 副作用で半角数字の幅が崩れる (#869)。数字表示を優先したい場合は
-          // OFF にして #861 以前の挙動に戻す。
-          if (colorEmojiFallbackConfigurable)
-            SwitchListTile(
-              title: const Text('カラー絵文字を使う'),
-              subtitle: const Text(
-                'Unicode 絵文字をカラーで表示します。'
-                'オフにすると一部の絵文字はモノクロになりますが、'
-                '半角数字などの文字幅の崩れを回避できます',
-              ),
-              value: ref.watch(colorEmojiFallbackProvider),
-              onChanged: (value) => ref
-                  .read(colorEmojiFallbackProvider.notifier)
-                  .setEnabled(value),
-            ),
           // 直配チャネル (Linux AppImage / Windows 自己署名 MSIX 直配) のみ
           // 意味がある設定 (#641)。ストア配布ビルドでは
           // [kIsDirectChannelBuild] が false なので、設定エントリ自体を隠す。

--- a/packages/capsicum/lib/src/ui/screen/settings/desktop_settings_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/desktop_settings_screen.dart
@@ -72,6 +72,23 @@ class DesktopSettingsScreen extends ConsumerWidget {
               onChanged: (value) =>
                   ref.read(launchAtLoginProvider.notifier).setEnabled(value),
             ),
+          // カラー絵文字フォールバック (#861 / #869)。Linux のみ意味がある。
+          // ON (既定) は #861 の対処で Unicode 絵文字をカラー表示するが、その
+          // 副作用で半角数字の幅が崩れる (#869)。数字表示を優先したい場合は
+          // OFF にして #861 以前の挙動に戻す。
+          if (colorEmojiFallbackConfigurable)
+            SwitchListTile(
+              title: const Text('カラー絵文字を使う'),
+              subtitle: const Text(
+                'Unicode 絵文字をカラーで表示します。'
+                'オフにすると一部の絵文字はモノクロになりますが、'
+                '半角数字などの文字幅の崩れを回避できます',
+              ),
+              value: ref.watch(colorEmojiFallbackProvider),
+              onChanged: (value) => ref
+                  .read(colorEmojiFallbackProvider.notifier)
+                  .setEnabled(value),
+            ),
           // 直配チャネル (Linux AppImage / Windows 自己署名 MSIX 直配) のみ
           // 意味がある設定 (#641)。ストア配布ビルドでは
           // [kIsDirectChannelBuild] が false なので、設定エントリ自体を隠す。

--- a/packages/capsicum/lib/src/ui/screen/settings/display_settings_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/display_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../platform/platform_info.dart';
 import '../../../provider/account_manager_provider.dart';
 import '../../../provider/preferences_provider.dart';
 
@@ -82,6 +83,22 @@ class DisplaySettingsScreen extends ConsumerWidget {
             onChanged: (_) =>
                 ref.read(emojiZeroWidthSpaceProvider.notifier).toggle(),
           ),
+          // カラー絵文字フォールバック (#861 / #869)。Linux のみ表示。ON (既定)
+          // は Unicode 絵文字をカラー表示するが、その副作用で半角数字の幅が
+          // 崩れる (#869)。数字表示を優先したい場合は OFF で #861 以前の挙動へ。
+          if (colorEmojiFallbackConfigurable)
+            SwitchListTile(
+              title: const Text('カラー絵文字を使う'),
+              subtitle: const Text(
+                'Unicode 絵文字をカラーで表示します。'
+                'オフにすると一部の絵文字はモノクロになりますが、'
+                '半角数字などの文字幅の崩れを回避できます',
+              ),
+              value: ref.watch(colorEmojiFallbackProvider),
+              onChanged: (value) => ref
+                  .read(colorEmojiFallbackProvider.notifier)
+                  .setEnabled(value),
+            ),
           SwitchListTile(
             title: const Text('MFM のアニメーションを再生'),
             subtitle: const Text(

--- a/packages/capsicum/pubspec.yaml
+++ b/packages/capsicum/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capsicum
 description: Flutter-based Mastodon / Misskey client
 publish_to: none
-version: 1.49.0+155
+version: 1.49.1+156
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
Linux で半角数字（0-9 / # / *）が絵文字フォントに横取りされ全画面で幅が崩れる #861 回帰（#869）のホットフィックス。

設定「カラー絵文字を使う」（デスクトップ設定・Linux のみ表示・既定 ON）を追加し、OFF で #861 以前の挙動に戻せるようにした。Linux 以外は既存挙動を変えない。詳細・経緯は #869。

## 検証
- OFF が通る経路は #861 導入前のコードそのもの（構造的に回帰を再現しない）、ON は現行 v1.49 のまま。
- pooza 環境では元々数字崩れが再現しないため、実機確認は「ON のまま正常・トグルが機能する」までのスモーク。実際の直り確認は報告元（rna 氏）。
- CI の Linux AppImage artifact で実機検証してからマージ・タグ。

## マージ後（リリース時）
- タグ `v1.49.1` → AppImage / 各ストア publish
- fix コミットを develop へ cherry-pick（v1.50 での回帰再発防止）
- develop を `1.50.0+157` へバンプ（本 HF が build 156 を取得したため衝突回避）