### PR TITLE
fix: ALT 編集の導線をモロヘイヤ 5.34.0 以降に限定する (#999)

### DIFF
--- a/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
@@ -117,7 +117,8 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   /// その API は「送らなかったパラメータ」を現状維持ではなく**空で更新**として
   /// 扱うため、素で呼ぶと **添付が全部外れ CW と閲覧注意も消える**
   /// （mulukhiya#4589）。現状維持すべき値を補完するのはモロヘイヤ 5.34.0 以降の
-  /// 役目なので、いない環境では導線ごと出さない。
+  /// 役目なので、**5.34.0 未満の環境では導線ごと出さない**（有無だけでなく版も
+  /// 見る・#999）。
   ///
   /// 判定を UI 層に置いているのは、アダプタからモロヘイヤの有無が見えないため
   /// （`MulukhiyaService` は `Account` が持つアプリ層の資産）。`TranslationSupport`
@@ -128,10 +129,16 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   bool get _canEdit {
     final currentUser = ref.read(currentAccountProvider)?.user;
     final adapter = ref.read(currentAdapterProvider);
+    final mulukhiya = ref.read(currentMulukhiyaProvider);
     return canEditAttachmentDescription(
       supportsMediaUpdate: adapter is MediaUpdateSupport,
       needsMulukhiya: adapter is MastodonAdapter,
-      hasMulukhiya: ref.read(currentMulukhiyaProvider) != null,
+      hasMulukhiya: mulukhiya != null,
+      // ⚠ **版まで見る (#999)。**5.33.0 は media_update を受理するが補完しない
+      // ので、有無だけで出すと投稿から添付が全部外れ CW も消える。
+      mulukhiyaHandlesMediaUpdate: mulukhiyaSupportsMediaUpdate(
+        mulukhiya?.version,
+      ),
       isOwnPost: currentUser != null && currentUser.id == widget.postAuthorId,
       hasPostContext: widget.postAuthorId != null && widget.postId != null,
     );

--- a/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
+++ b/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
@@ -1,3 +1,26 @@
+import '../../service/server_version_checker.dart';
+
+/// ALT 編集の PUT を安全に受けられる最小のモロヘイヤ版 (#999)。
+///
+/// これ未満のモロヘイヤは `X-Mulukhiya-Purpose: media_update` を**受理はする**が、
+/// 上流へ送る body が `{status, media_attributes}` だけで `media_ids` /
+/// `spoiler_text` / `sensitive` を補完しない（5.33.0 の `mastodon_controller.rb`）。
+/// nginx の `$status_put_backend` map は 5.33.0 にもあるので **405 では止まらず、
+/// 投稿から添付が全部外れ CW と閲覧注意も消える**。補完が入るのは 5.34.0 から。
+const kMulukhiyaMediaUpdateMinVersion = '5.34.0';
+
+/// モロヘイヤの版が ALT 編集の補完を持つか (#999)。[version] が null（モロヘイヤ
+/// 不在・版が読めない）なら false に倒す。**判定を誤ると投稿が壊れる側なので、
+/// 「分からない」は常に「出さない」に寄せる。**
+bool mulukhiyaSupportsMediaUpdate(String? version) {
+  if (version == null || version.isEmpty) return false;
+
+  return ServerVersionChecker.isAtLeast(
+    version,
+    kMulukhiyaMediaUpdateMinVersion,
+  );
+}
+
 /// 投稿済みメディアの説明（ALT）を編集する導線を出してよいか (#121)。
 ///
 /// ⚠ **間違えると投稿が壊れる判定なので、画面から切り出してテストで固定する。**
@@ -13,6 +36,8 @@
 /// - [needsMulukhiya] … その API がモロヘイヤの補完を前提にするか（Mastodon は
 ///   true、Misskey は `drive/files/update` が投稿済みでも効くので false）
 /// - [hasMulukhiya] … 現在のアカウントのサーバーにモロヘイヤがいるか
+/// - [mulukhiyaHandlesMediaUpdate] … そのモロヘイヤが**補完を持つ版**か
+///   （5.34.0 以降。[mulukhiyaSupportsMediaUpdate] で判定する・#999）
 /// - [isOwnPost] … 自分の投稿か（他人の添付は編集できない）
 /// - [hasPostContext] … 投稿 id と投稿者 id が揃っているか。メディアビューアは
 ///   投稿を伴わない経路からも開くため、揃わないことがある
@@ -20,11 +45,15 @@ bool canEditAttachmentDescription({
   required bool supportsMediaUpdate,
   required bool needsMulukhiya,
   required bool hasMulukhiya,
+  required bool mulukhiyaHandlesMediaUpdate,
   required bool isOwnPost,
   required bool hasPostContext,
 }) {
   if (!hasPostContext) return false;
   if (!supportsMediaUpdate) return false;
-  if (needsMulukhiya && !hasMulukhiya) return false;
+  // ⚠ **有無だけでなく版も見る (#999)。**有無しか見ていなかったため、補完の無い
+  // 5.33.0 のサーバーでも導線が出ていた（自前 4 サーバーが全部これだった）。
+  final mulukhiyaReady = hasMulukhiya && mulukhiyaHandlesMediaUpdate;
+  if (needsMulukhiya && !mulukhiyaReady) return false;
   return isOwnPost;
 }

--- a/packages/capsicum/test/attachment_description_edit_test.dart
+++ b/packages/capsicum/test/attachment_description_edit_test.dart
@@ -14,12 +14,14 @@ void main() {
     bool supportsMediaUpdate = true,
     bool needsMulukhiya = true,
     bool hasMulukhiya = true,
+    bool mulukhiyaHandlesMediaUpdate = true,
     bool isOwnPost = true,
     bool hasPostContext = true,
   }) => canEditAttachmentDescription(
     supportsMediaUpdate: supportsMediaUpdate,
     needsMulukhiya: needsMulukhiya,
     hasMulukhiya: hasMulukhiya,
+    mulukhiyaHandlesMediaUpdate: mulukhiyaHandlesMediaUpdate,
     isOwnPost: isOwnPost,
     hasPostContext: hasPostContext,
   );
@@ -35,6 +37,44 @@ void main() {
         isFalse,
         reason: '補完なしで通すと添付が全部外れ CW も消える（mulukhiya#4589）',
       );
+    });
+
+    // ⚠ **#999 の本題。**「いるか」だけを見ていたため、補完を持たない 5.33.0 でも
+    // 導線が出ていた（自前 4 サーバーが全部これだった）。5.33.0 は
+    // media_update を受理してしまい、nginx の map も 405 で止めないので、
+    // 出した時点で投稿が壊れる経路が開く。
+    test('モロヘイヤがいても補完を持たない版なら出さない', () {
+      expect(
+        can(mulukhiyaHandlesMediaUpdate: false),
+        isFalse,
+        reason: '5.33.0 は media_update を受理するが media_ids 等を補完しない',
+      );
+    });
+  });
+
+  group('モロヘイヤの版判定 (#999)', () {
+    test('5.34.0 以降は補完を持つ', () {
+      expect(mulukhiyaSupportsMediaUpdate('5.34.0'), isTrue);
+      expect(mulukhiyaSupportsMediaUpdate('5.34.1'), isTrue);
+      expect(mulukhiyaSupportsMediaUpdate('6.0.0'), isTrue);
+    });
+
+    test('5.34.0 未満は持たない', () {
+      expect(mulukhiyaSupportsMediaUpdate('5.33.0'), isFalse);
+      expect(mulukhiyaSupportsMediaUpdate('5.9.0'), isFalse);
+      expect(
+        mulukhiyaSupportsMediaUpdate('5.33.99'),
+        isFalse,
+        reason: 'minor が下なら patch がいくつでも未満',
+      );
+    });
+
+    // ⚠ **「分からない」は「出さない」に倒す。**判定を誤る側の代償が
+    // 「投稿が壊れる」なので、版が読めないときに通してはいけない。
+    test('版が無い・読めないときは出さない', () {
+      expect(mulukhiyaSupportsMediaUpdate(null), isFalse);
+      expect(mulukhiyaSupportsMediaUpdate(''), isFalse);
+      expect(mulukhiyaSupportsMediaUpdate('unknown'), isFalse);
     });
   });
 


### PR DESCRIPTION
v1.59 の出荷ゲート。`canEditAttachmentDescription` が**モロヘイヤの「有無」しか見ておらず**、補完を持たない 5.33.0 のサーバーでも ALT 編集の導線が出ていた。**自前 4 サーバーは全部 5.33.0** なので、このまま出荷すると投稿が壊れる経路が本番で開く。

## 何が起きるか

| 段 | 5.33.0 の挙動 |
| --- | --- |
| nginx | `$status_put_backend` map は **5.33.0 の sample にも既にある**ので、Purpose 付き PUT は 405 で止まらずモロヘイヤへ届く |
| モロヘイヤ | `media_update` を**受理する**。ただし上流へ送る body は `{status: source['text'], media_attributes: ...}` だけで **`media_ids` / `spoiler_text` / `sensitive` を補完しない** |
| Mastodon | 送らなかったパラメータを**空で更新**として扱う → **添付が全部外れ、CW と閲覧注意も消える**（mulukhiya#4589） |

補完が入るのは **5.34.0**（mulukhiya develop の `3cf80f067`）から。

## 直し方

判定に版の条件を足した。版比較は `ServerVersionChecker.isAtLeast` を再利用している（「機能が特定バージョンで追加された API のゲートに使う」と doc に書かれている既存の道具。Collections=4.6 の #810 と同型）。

```dart
final mulukhiyaReady = hasMulukhiya && mulukhiyaHandlesMediaUpdate;
if (needsMulukhiya && !mulukhiyaReady) return false;
```

⚠ **「分からない」は常に「出さない」へ倒す。** 版が null / 空 / 非数値のときは false。誤る側の代償が「投稿が壊れる」ため。

Misskey は `drive/files/update` が投稿済みでも効くので `needsMulukhiya: false`＝この条件を通らない（従来どおり無条件で出る）。

## 検証

- `flutter test` … 913 tests / All passed
- `dart analyze --fatal-infos` … No issues found
- `dart format` … 差分なし
- 新規テスト: 補完を持たない版で出ないこと / 5.34.0 以降で出ること / 5.33.99 が未満と判定されること / 版が読めないとき出ないこと

## 残る作業

本 PR は**導線を閉じる**だけ。ALT 編集そのものの完成（実トークンでの往復確認）は #121 で v1.60。モロヘイヤ 5.34.0 が本番に入れば、この判定は**自動的に導線を復活させる**（再リリース不要）。

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
