### PR TITLE
feat: 設定バックアップにアカウント索引を含めて移行先で復元する (#1001)

### DIFF
--- a/packages/capsicum/lib/src/provider/account_manager_provider.dart
+++ b/packages/capsicum/lib/src/provider/account_manager_provider.dart
@@ -877,6 +877,36 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
     state = state.copyWith(offlineAccounts: updated);
   }
 
+  /// 設定バックアップの取り込みで索引へ足したアカウントを、**再起動を待たずに**
+  /// 「未接続」として一覧へ出す (#1001)。
+  ///
+  /// ⚠ **これが無いと「n 件のアカウントを追加しました」が嘘になる。**索引
+  /// （`capsicum_account_keys_v2`）は [restoreSessions] が起動時に 1 度だけ
+  /// 読むので、実行中に足しても次の起動まで画面に出ない。
+  ///
+  /// ⚠ **[restoreSessions] を呼び直さない。**あちらは全アカウントを probe し直す
+  /// 起動経路で、取り込みのたびに走らせるには重い。足したぶんだけを
+  /// `OfflineAccount.secretMissing` として積む（トークンが無いので probe は
+  /// そもそも組み立てられない）。
+  ///
+  /// 既にオンライン / オフラインで居るアカウントは触らない（取り込みは
+  /// **マージ**であって置き換えではない）。
+  void addDisconnectedAccounts(Iterable<AccountKey> keys) {
+    final known = {
+      ...state.accounts.map((a) => a.key),
+      ...state.offlineAccounts.map((o) => o.key),
+    };
+    final added = keys
+        .where(known.add)
+        .map((key) => OfflineAccount.secretMissing(key: key))
+        .toList();
+    if (added.isEmpty) return;
+
+    state = state.copyWith(
+      offlineAccounts: [...state.offlineAccounts, ...added],
+    );
+  }
+
   /// オフライン保持中のアカウントを「未接続」へ落とす (#967)。到達不能を待って
   /// いる間に secret が消えた場合に使う。⚠ **一覧からは消さない**——消すと
   /// #792 で直した「サーバーごと存在しないように見える」に戻る。

--- a/packages/capsicum/lib/src/service/account_storage.dart
+++ b/packages/capsicum/lib/src/service/account_storage.dart
@@ -34,7 +34,13 @@ class TransientSecretUnavailableException implements Exception {
 /// entry for the index wipes every account.
 class AccountStorage {
   static const _legacyAccountListKey = 'capsicum_account_keys';
-  static const _accountListKey = 'capsicum_account_keys_v2';
+
+  /// アカウント索引の SharedPreferences キー。⚠ **設定バックアップ (#1001) が
+  /// ここへ書き戻す**ので公開している。値は `AccountKey.toStorageKey()`
+  /// （`mastodon://user@host`）の JSON 配列で、**host + username だけを持つ
+  /// 非秘匿値**（secret は secure storage 側）。
+  static const accountListKey = 'capsicum_account_keys_v2';
+  static const _accountListKey = accountListKey;
   // _v1 は #643 の初版で導入したが、当時の migration / write が旧 item を
   // accessibility 取りこぼしで救えておらず（後述）空振りでフラグだけ立てて
   // いた。修正版を全員に再実行させるため _v2 に上げる (内部ベータ

--- a/packages/capsicum/lib/src/service/settings_backup.dart
+++ b/packages/capsicum/lib/src/service/settings_backup.dart
@@ -199,14 +199,22 @@ List<String> readAccountKeysForBackup(SharedPreferences prefs) {
   }
 }
 
-bool _isParsableAccountKey(String key) {
+/// storage key を**正規形**に直す。読めなければ null (#1001)。
+///
+/// ⚠ **正規化せずに保存すると同じアカウントが 2 行に割れる**（Codex P2 /
+/// PR #1002）。手で編集したバックアップに `mastodon://alice@example.com/` のような
+/// 非正規形が入っていると、parse は通るのに `toStorageKey()` とは別文字列なので、
+/// 接続し直した後に `saveAccount` が正規形を**別のアカウントとして**足す。次の
+/// 起動で「トークンのある行」と「未接続の行」が同じアカウントに対して並ぶ。
+String? _canonicalAccountKey(String key) {
   try {
-    AccountKey.fromStorageKey(key);
-    return true;
+    return AccountKey.fromStorageKey(key).toStorageKey();
   } catch (_) {
-    return false;
+    return null;
   }
 }
+
+bool _isParsableAccountKey(String key) => _canonicalAccountKey(key) != null;
 
 void _writeAccounts(StringBuffer buffer, SharedPreferences prefs) {
   final keys = readAccountKeysForBackup(prefs);
@@ -366,8 +374,10 @@ Future<List<String>> _mergeAccounts(
   final added = <String>[];
   var invalid = 0;
   for (final entry in node) {
-    final key = entry is String ? entry : null;
-    if (key == null || !_isParsableAccountKey(key)) {
+    // ⚠ **正規形にしてから入れる。**非正規形のまま保存すると、接続し直した後に
+    // 同じアカウントが 2 行（トークンあり / 未接続）に割れる。
+    final key = entry is String ? _canonicalAccountKey(entry) : null;
+    if (key == null) {
       invalid++;
       continue;
     }

--- a/packages/capsicum/lib/src/service/settings_backup.dart
+++ b/packages/capsicum/lib/src/service/settings_backup.dart
@@ -206,9 +206,18 @@ List<String> readAccountKeysForBackup(SharedPreferences prefs) {
 /// 非正規形が入っていると、parse は通るのに `toStorageKey()` とは別文字列なので、
 /// 接続し直した後に `saveAccount` が正規形を**別のアカウントとして**足す。次の
 /// 起動で「トークンのある行」と「未接続の行」が同じアカウントに対して並ぶ。
+/// ⚠ **host / username の欠けは parse では落ちない（Codex P2 / PR #1002）。**
+/// `AccountKey.fromStorageKey` は `Uri.parse` に乗っているだけなので、
+/// `mastodon://alice` は host=`alice` / username=`` として通り、正規形は
+/// `mastodon://@alice` になる。そのまま索引へ入れると、**復帰できない未接続の行**
+/// を作ったうえで「アカウントを追加しました」と報告してしまう。両方が揃って
+/// いることを確かめる。
 String? _canonicalAccountKey(String key) {
   try {
-    return AccountKey.fromStorageKey(key).toStorageKey();
+    final parsed = AccountKey.fromStorageKey(key);
+    if (parsed.host.isEmpty || parsed.username.isEmpty) return null;
+
+    return parsed.toStorageKey();
   } catch (_) {
     return null;
   }

--- a/packages/capsicum/lib/src/service/settings_backup.dart
+++ b/packages/capsicum/lib/src/service/settings_backup.dart
@@ -1,16 +1,24 @@
-/// 設定のバックアップ（書き出し / 読み込み）(#857)。
+/// 設定のバックアップ（書き出し / 読み込み）(#857 / #1001)。
 ///
-/// **対象は設定だけで、アカウントは含まない。**アクセストークンを平文 YAML に
-/// 並べると、ファイル 1 つの流出で全アカウントが乗っ取られるため。インポート後に
-/// アカウントを「未接続」として復元する話は #967 に分離した。
+/// **アクセストークンは含まない。**平文 YAML に並べると、ファイル 1 つの流出で
+/// 全アカウントが乗っ取られるため。⚠ **だからこそ「再接続」が要る** — 移行先へ
+/// 持っていくのは**アカウント索引（host + username）だけ**で、トークンの無い
+/// アカウントは「未接続」として一覧に並び、ログインし直すとトークンが再設定
+/// されて復帰する（#967）。索引と再接続で 1 つの筋書きなので、片方だけでは
+/// 「スマホと PC でアカウントを同期する」は成立しない。
 ///
-/// **端末固有の値も書かない**（[deviceLocalKeys]）。「書くがインポート時に無視」は、
+/// **端末固有の値は書かない**（[deviceLocalKeys]）。「書くがインポート時に無視」は、
 /// ファイルに載っているのに反映されない混乱を生むので採らない。#952 で
 /// 「その端末だけの値を複製すると壊れる」ことを実証したのと同型の判断。
 library;
 
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yaml/yaml.dart';
+
+import '../model/account_key.dart';
+import 'account_storage.dart';
 
 /// ファイル形式の版。読み込み側は未知の版を弾く。
 const settingsBackupFormatVersion = 1;
@@ -135,7 +143,11 @@ const accountScopedKeys = <String>{
 
 /// 読み込み結果。
 class SettingsImportResult {
-  const SettingsImportResult({required this.applied, required this.skipped});
+  const SettingsImportResult({
+    required this.applied,
+    required this.skipped,
+    this.addedAccounts = 0,
+  });
 
   /// 実際に書き込んだ設定のキー。
   final List<String> applied;
@@ -143,6 +155,11 @@ class SettingsImportResult {
   /// ファイルにあったが取り込まなかったキーと理由。端末固有値・未知のキー・
   /// 型違いをここへ集め、画面で「何を無視したか」を出せるようにする。
   final Map<String, String> skipped;
+
+  /// 索引へ新しく足したアカウント数 (#1001)。**トークンは入っていない**ので、
+  /// これらは「未接続」として一覧に並ぶ（#967）。画面で「n 件のアカウントを
+  /// 追加しました。ログインし直してください」を出すために使う。
+  final int addedAccounts;
 }
 
 /// 読み込めないファイルを渡されたときに投げる。
@@ -157,6 +174,47 @@ class SettingsBackupFormatException implements Exception {
 
 /// 現在の設定を YAML にする (#857)。
 ///
+/// バックアップの `accounts:` に載せるアカウント索引を読む (#1001)。
+///
+/// 値は `AccountKey.toStorageKey()`（`mastodon://user@host`）の JSON 配列で、
+/// **host + username だけを持つ非秘匿値**（`AccountStorage` の doc 参照。だから
+/// SharedPreferences に置いている）。⚠ **secret は載せない。**平文 YAML に
+/// トークンが並ぶと、ファイル 1 つの流出で全アカウントが乗っ取られる（#857 で
+/// 確定した方針）。移行先ではトークンが無いので「未接続」として並び、ログイン
+/// し直すと復帰する（#967）。
+List<String> readAccountKeysForBackup(SharedPreferences prefs) {
+  final encoded = prefs.getString(AccountStorage.accountListKey);
+  if (encoded == null) return const [];
+  try {
+    final decoded = jsonDecode(encoded);
+    if (decoded is! List) return const [];
+    return decoded.whereType<String>().where(_isParsableAccountKey).toList();
+  } catch (_) {
+    // 索引の JSON 破損。書き出し側で拾っても直せないので黙って空にする
+    // （AccountStorage.getAccountKeys も同じ扱い）。
+    return const [];
+  }
+}
+
+bool _isParsableAccountKey(String key) {
+  try {
+    AccountKey.fromStorageKey(key);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+void _writeAccounts(StringBuffer buffer, SharedPreferences prefs) {
+  final keys = readAccountKeysForBackup(prefs);
+  if (keys.isEmpty) return;
+
+  buffer.writeln('accounts:');
+  for (final key in keys) {
+    buffer.writeln('  - ${_yamlString(key)}');
+  }
+}
+
 /// 未設定（既定値のまま）のキーは**書かない**。既定値を焼き込むと、後で既定が
 /// 変わったときに古い既定値が復活してしまう。
 String buildSettingsBackupYaml(
@@ -166,11 +224,14 @@ String buildSettingsBackupYaml(
 }) {
   final buffer = StringBuffer()
     ..writeln('# capsicum の設定バックアップ')
-    ..writeln('# アカウント・認証情報は含まれません。')
+    ..writeln('# アカウントの一覧（サーバーとユーザー名）を含みます。')
+    ..writeln('# パスワードとアクセストークンは含まれません。')
     ..writeln('version: $settingsBackupFormatVersion')
     ..writeln('app_version: ${_yamlString(appVersion)}')
-    ..writeln('exported_at: ${_yamlString(exportedAt)}')
-    ..writeln('settings:');
+    ..writeln('exported_at: ${_yamlString(exportedAt)}');
+
+  _writeAccounts(buffer, prefs);
+  buffer.writeln('settings:');
 
   var wrote = false;
   for (final setting in exportableSettings) {
@@ -238,6 +299,11 @@ Future<SettingsImportResult> applySettingsBackupYaml(
   final byKey = {for (final s in exportableSettings) s.key: s};
   final applied = <String>[];
   final skipped = <String, String>{};
+  final addedAccounts = await _mergeAccounts(
+    prefs,
+    parsed['accounts'],
+    skipped,
+  );
 
   for (final entry in settings.nodes.entries) {
     final key = entry.key.toString();
@@ -262,7 +328,66 @@ Future<SettingsImportResult> applySettingsBackupYaml(
     }
     applied.add(key);
   }
-  return SettingsImportResult(applied: applied, skipped: skipped);
+  return SettingsImportResult(
+    applied: applied,
+    skipped: skipped,
+    addedAccounts: addedAccounts,
+  );
+}
+
+/// バックアップの `accounts:` を索引へ**マージ**する (#1001)。返り値は新しく
+/// 足したアカウント数。
+///
+/// ⚠ **既存のアカウントを消さない。**移行先に既にアカウントが居ることがあり、
+/// 置き換えると「読み込んだら手元のアカウントが消えた」になる。既にある key は
+/// 何もしない（重複させない）。
+///
+/// ⚠ **secret は触らない。**索引だけが増えるので、足したアカウントは
+/// 「未接続」として並ぶ（#967）。ログインし直すとトークンが入って復帰する。
+///
+/// 壊れた要素は黙って捨てず [skipped] に理由を積む。ファイル全体を捨てないのは
+/// 設定側と同じ方針。
+Future<int> _mergeAccounts(
+  SharedPreferences prefs,
+  Object? node,
+  Map<String, String> skipped,
+) async {
+  if (node == null) return 0;
+  if (node is! YamlList) {
+    skipped['accounts'] = 'アカウントの一覧が読めませんでした';
+    return 0;
+  }
+
+  final existing = readAccountKeysForBackup(prefs);
+  final merged = [...existing];
+  var added = 0;
+  var invalid = 0;
+  for (final entry in node) {
+    final key = entry is String ? entry : null;
+    if (key == null || !_isParsableAccountKey(key)) {
+      invalid++;
+      continue;
+    }
+    if (merged.contains(key)) continue;
+    merged.add(key);
+    added++;
+  }
+  if (invalid > 0) {
+    skipped['accounts'] = '$invalid 件のアカウントを読み取れませんでした';
+  }
+  if (added == 0) return 0;
+
+  // ⚠ setString は失敗しても throw せず false を返す（AccountStorage と同じ罠）。
+  // 失敗を成功として報告すると「読み込んだのに増えていない」が無言になる。
+  final ok = await prefs.setString(
+    AccountStorage.accountListKey,
+    jsonEncode(merged),
+  );
+  if (!ok) {
+    skipped['accounts'] = 'アカウントの一覧を保存できませんでした';
+    return 0;
+  }
+  return added;
 }
 
 Object? _readValue(SharedPreferences prefs, BackupSetting setting) =>

--- a/packages/capsicum/lib/src/service/settings_backup.dart
+++ b/packages/capsicum/lib/src/service/settings_backup.dart
@@ -146,7 +146,7 @@ class SettingsImportResult {
   const SettingsImportResult({
     required this.applied,
     required this.skipped,
-    this.addedAccounts = 0,
+    this.addedAccountKeys = const [],
   });
 
   /// 実際に書き込んだ設定のキー。
@@ -156,10 +156,13 @@ class SettingsImportResult {
   /// 型違いをここへ集め、画面で「何を無視したか」を出せるようにする。
   final Map<String, String> skipped;
 
-  /// 索引へ新しく足したアカウント数 (#1001)。**トークンは入っていない**ので、
-  /// これらは「未接続」として一覧に並ぶ（#967）。画面で「n 件のアカウントを
-  /// 追加しました。ログインし直してください」を出すために使う。
-  final int addedAccounts;
+  /// 索引へ新しく足したアカウントの storage key (#1001)。**トークンは入って
+  /// いない**ので、これらは「未接続」として一覧に並ぶ（#967）。
+  ///
+  /// ⚠ **件数だけでなく key を返す。**呼び出し側が実行中の一覧へ反映する
+  /// （[AccountManagerNotifier.addDisconnectedAccounts]）ために要る。件数だけだと
+  /// 「追加しました」と言いながら次の起動まで画面に出ない。
+  final List<String> addedAccountKeys;
 }
 
 /// 読み込めないファイルを渡されたときに投げる。
@@ -299,7 +302,7 @@ Future<SettingsImportResult> applySettingsBackupYaml(
   final byKey = {for (final s in exportableSettings) s.key: s};
   final applied = <String>[];
   final skipped = <String, String>{};
-  final addedAccounts = await _mergeAccounts(
+  final addedAccountKeys = await _mergeAccounts(
     prefs,
     parsed['accounts'],
     skipped,
@@ -331,12 +334,12 @@ Future<SettingsImportResult> applySettingsBackupYaml(
   return SettingsImportResult(
     applied: applied,
     skipped: skipped,
-    addedAccounts: addedAccounts,
+    addedAccountKeys: addedAccountKeys,
   );
 }
 
 /// バックアップの `accounts:` を索引へ**マージ**する (#1001)。返り値は新しく
-/// 足したアカウント数。
+/// 足したアカウントの storage key。
 ///
 /// ⚠ **既存のアカウントを消さない。**移行先に既にアカウントが居ることがあり、
 /// 置き換えると「読み込んだら手元のアカウントが消えた」になる。既にある key は
@@ -347,20 +350,20 @@ Future<SettingsImportResult> applySettingsBackupYaml(
 ///
 /// 壊れた要素は黙って捨てず [skipped] に理由を積む。ファイル全体を捨てないのは
 /// 設定側と同じ方針。
-Future<int> _mergeAccounts(
+Future<List<String>> _mergeAccounts(
   SharedPreferences prefs,
   Object? node,
   Map<String, String> skipped,
 ) async {
-  if (node == null) return 0;
+  if (node == null) return const [];
   if (node is! YamlList) {
     skipped['accounts'] = 'アカウントの一覧が読めませんでした';
-    return 0;
+    return const [];
   }
 
   final existing = readAccountKeysForBackup(prefs);
   final merged = [...existing];
-  var added = 0;
+  final added = <String>[];
   var invalid = 0;
   for (final entry in node) {
     final key = entry is String ? entry : null;
@@ -370,12 +373,12 @@ Future<int> _mergeAccounts(
     }
     if (merged.contains(key)) continue;
     merged.add(key);
-    added++;
+    added.add(key);
   }
   if (invalid > 0) {
     skipped['accounts'] = '$invalid 件のアカウントを読み取れませんでした';
   }
-  if (added == 0) return 0;
+  if (added.isEmpty) return const [];
 
   // ⚠ setString は失敗しても throw せず false を返す（AccountStorage と同じ罠）。
   // 失敗を成功として報告すると「読み込んだのに増えていない」が無言になる。
@@ -385,7 +388,7 @@ Future<int> _mergeAccounts(
   );
   if (!ok) {
     skipped['accounts'] = 'アカウントの一覧を保存できませんでした';
-    return 0;
+    return const [];
   }
   return added;
 }

--- a/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
@@ -1,13 +1,21 @@
+import 'dart:io';
+
 import 'package:capsicum_backends/capsicum_backends.dart';
 import 'package:dio/dio.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../constants.dart';
+import '../../model/account_key.dart';
 import '../../preset_servers.dart';
+import '../../service/settings_backup.dart';
+import '../../platform/platform_info.dart';
 import '../../url_helper.dart';
 import '../../util/exception_scrub.dart';
+import '../util/settings_backup_file_type.dart';
 
 class ServerSelectionScreen extends ConsumerStatefulWidget {
   const ServerSelectionScreen({super.key, this.initialHost});
@@ -28,10 +36,79 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
   bool _isProbing = false;
   String? _error;
 
+  /// バックアップ取り込み中（二重起動を止める）。
+  bool _importing = false;
+
+  /// 取り込んだアカウントのホスト。⚠ **ログイン前はアカウント一覧の画面が無い**
+  /// ので、ここに出さないと「読み込めたのか」がユーザーから見えない (#1001)。
+  List<String> _importedHosts = const [];
+
   @override
   void dispose() {
     _hostController.dispose();
     super.dispose();
+  }
+
+  /// バックアップを取り込む (#1001)。**ログイン前でも使える唯一の導線**。
+  ///
+  /// 取り込むのは設定とアカウント索引だけで、トークンは入っていない（#857）。
+  /// したがってここで即ログイン状態にはならない。**ホスト名を埋めて、ログインへ
+  /// 送るところまで**が役割で、ログインすると残りは「未接続」として一覧に並ぶ
+  /// （#967）。
+  Future<void> _importBackup() async {
+    final file = await openFile(
+      acceptedTypeGroups: [
+        settingsBackupTypeGroup(needsUti: fileTypeFilterNeedsUti),
+      ],
+    );
+    if (file == null || !mounted) return;
+
+    setState(() {
+      _importing = true;
+      _error = null;
+    });
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final text = await File(file.path).readAsString();
+      final prefs = await SharedPreferences.getInstance();
+      final result = await applySettingsBackupYaml(prefs, text);
+      if (!mounted) return;
+
+      final hosts = <String>[];
+      for (final raw in result.addedAccountKeys) {
+        try {
+          hosts.add(AccountKey.fromStorageKey(raw).host);
+        } catch (_) {
+          continue;
+        }
+      }
+      setState(() {
+        _importedHosts = hosts.toSet().toList();
+        // 最初のホストを埋めておく。移行直後にホスト名を打ち直させない
+        // （#967 の「接続し直す」導線と同じ考え方）。
+        if (_hostController.text.isEmpty && hosts.isNotEmpty) {
+          _hostController.text = hosts.first;
+        }
+      });
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            hosts.isEmpty
+                ? '設定を読み込みました'
+                : '設定と ${result.addedAccountKeys.length} 件のアカウントを読み込みました。'
+                      'ログインすると使えるようになります',
+          ),
+        ),
+      );
+    } on SettingsBackupFormatException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text(e.message)));
+    } catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text('読み込めませんでした: $e')));
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
   }
 
   Future<void> _connectTo(String host) async {
@@ -146,6 +223,27 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
                 ),
                 const SizedBox(height: 16),
                 FilledButton(onPressed: _onSubmit, child: const Text('接続')),
+                const Divider(height: 32),
+                // ⚠ **ログイン前に置く**（Codex P1 / PR #1002）。設定画面は
+                // セッションが無いと router が /server へ引き戻すので、新しい
+                // 端末では到達できない。**移行はここから始まる**ので、バック
+                // アップの取り込みだけはログイン前に要る (#1001)。
+                Center(
+                  child: TextButton.icon(
+                    icon: const Icon(Icons.download),
+                    label: const Text('バックアップから設定とアカウントを読み込む'),
+                    onPressed: _importing ? null : _importBackup,
+                  ),
+                ),
+                if (_importedHosts.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      '読み込んだアカウント: ${_importedHosts.join(" / ")}\n'
+                      '上のサーバーを選んでログインすると使えるようになります。',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
               ],
             ),
     );

--- a/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
@@ -15,6 +15,7 @@ import '../../service/settings_backup.dart';
 import '../../platform/platform_info.dart';
 import '../../url_helper.dart';
 import '../../util/exception_scrub.dart';
+import '../util/settings_backup_apply.dart';
 import '../util/settings_backup_file_type.dart';
 
 class ServerSelectionScreen extends ConsumerStatefulWidget {
@@ -73,6 +74,11 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
       final prefs = await SharedPreferences.getInstance();
       final result = await applySettingsBackupYaml(prefs, text);
       if (!mounted) return;
+      // ⚠ **ここでも反映する（Codex P2 / PR #1002）。**索引と prefs を書いた
+      // だけでは、テーマ / 文字サイズは main.dart が読んだ古い値のままだし、
+      // 取り込んだアカウントも次の起動まで一覧に出ない。ログイン後の経路と
+      // 同じヘルパーを通す。
+      applyImportedSettingsBackup(ref, result);
 
       final hosts = <String>[];
       for (final raw in result.addedAccountKeys) {

--- a/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
@@ -9,12 +9,10 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../model/account_key.dart';
 import '../../../platform/platform_info.dart';
-import '../../../provider/account_manager_provider.dart';
-import '../../../provider/preferences_provider.dart';
 import '../../../service/sentry_op_failure.dart';
 import '../../../service/settings_backup.dart';
+import '../../util/settings_backup_apply.dart';
 import '../../util/settings_backup_file_type.dart';
 
 /// 設定のバックアップ (#857)。
@@ -164,8 +162,9 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
       if (!mounted) return;
       // 各 Notifier は build() で prefs を読み直すので、invalidate すれば
       // 画面が新しい設定で組み直される（再起動を求めない）。
-      _refreshPreferenceProviders();
-      _hydrateImportedAccounts(result);
+      // 設定とアカウントの反映は共通ヘルパーへ寄せてある（ログイン前の経路と
+      // 割れないようにするため・Codex P2 / PR #1002）。
+      applyImportedSettingsBackup(ref, result);
       _reportImportSkips(result);
       messenger.showSnackBar(SnackBar(content: Text(_importSummary(result))));
     } on SettingsBackupFormatException catch (e, st) {
@@ -247,34 +246,6 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
 
   /// 取り込んだ値を画面へ反映する (#857)。
   ///
-  /// 取り込んだアカウントを実行中の一覧へ出す (#1001)。
-  ///
-  /// ⚠ **索引を書いただけでは画面に出ない。**`restoreSessions` は起動時に 1 度
-  /// だけ索引を読むので、これが無いと「n 件のアカウントを追加しました」と言い
-  /// ながら次の起動まで現れない（Codex P2 / PR #1002）。
-  void _hydrateImportedAccounts(SettingsImportResult result) {
-    if (result.addedAccountKeys.isEmpty) return;
-
-    final keys = <AccountKey>[];
-    for (final raw in result.addedAccountKeys) {
-      try {
-        keys.add(AccountKey.fromStorageKey(raw));
-      } catch (_) {
-        // 取り込み側が parse 済みなので通常は来ない。保険。
-        continue;
-      }
-    }
-    ref.read(accountManagerProvider.notifier).addDisconnectedAccounts(keys);
-  }
-
-  /// **[exportableSettings] と 1:1 で対応させること。**ここに足し忘れると、
-  /// 値は書き込まれているのに次の起動まで画面へ出ない。
-  void _refreshPreferenceProviders() {
-    for (final provider in backedUpPreferenceProviders) {
-      ref.invalidate(provider);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
@@ -131,7 +131,11 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('設定を読み込む'),
-        content: const Text('この端末の設定が、ファイルの内容で上書きされます。よろしいですか？'),
+        content: const Text(
+          'この端末の設定が、ファイルの内容で上書きされます。\n'
+          'ファイルに入っているアカウントは一覧へ追加されます'
+          '（この端末の既存のアカウントは消えません）。よろしいですか？',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -218,10 +222,20 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
   }
 
   String _importSummary(SettingsImportResult result) {
-    if (result.applied.isEmpty && result.skipped.isEmpty) {
+    if (result.applied.isEmpty &&
+        result.skipped.isEmpty &&
+        result.addedAccounts == 0) {
       return 'このファイルに取り込める設定はありませんでした';
     }
     final buffer = StringBuffer('${result.applied.length} 件の設定を読み込みました');
+    // ⚠ **アカウントは「追加した」で止め、使えるとは言わない** (#1001)。
+    // トークンは移らないので、ログインし直すまで未接続のまま並ぶ (#967)。
+    if (result.addedAccounts > 0) {
+      buffer.write(
+        '。${result.addedAccounts} 件のアカウントを追加しました'
+        '（未接続。ログインし直すと使えます）',
+      );
+    }
     if (result.skipped.isNotEmpty) {
       buffer.write('（${result.skipped.length} 件は取り込みませんでした）');
     }
@@ -251,7 +265,9 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
             padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: Text(
               'この端末の設定をファイルに書き出し、別の端末で読み込めます。\n'
-              'アカウントと認証情報は含まれません。読み込んだあとにログインし直してください。',
+              'アカウントの一覧（サーバーとユーザー名）も含まれますが、'
+              'パスワードとアクセストークンは含まれません。\n'
+              '読み込んだアカウントは「未接続」として並ぶので、ログインし直すと使えるようになります。',
             ),
           ),
           ListTile(

--- a/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
@@ -9,7 +9,9 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../model/account_key.dart';
 import '../../../platform/platform_info.dart';
+import '../../../provider/account_manager_provider.dart';
 import '../../../provider/preferences_provider.dart';
 import '../../../service/sentry_op_failure.dart';
 import '../../../service/settings_backup.dart';
@@ -163,6 +165,7 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
       // 各 Notifier は build() で prefs を読み直すので、invalidate すれば
       // 画面が新しい設定で組み直される（再起動を求めない）。
       _refreshPreferenceProviders();
+      _hydrateImportedAccounts(result);
       _reportImportSkips(result);
       messenger.showSnackBar(SnackBar(content: Text(_importSummary(result))));
     } on SettingsBackupFormatException catch (e, st) {
@@ -224,15 +227,15 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
   String _importSummary(SettingsImportResult result) {
     if (result.applied.isEmpty &&
         result.skipped.isEmpty &&
-        result.addedAccounts == 0) {
+        result.addedAccountKeys.isEmpty) {
       return 'このファイルに取り込める設定はありませんでした';
     }
     final buffer = StringBuffer('${result.applied.length} 件の設定を読み込みました');
     // ⚠ **アカウントは「追加した」で止め、使えるとは言わない** (#1001)。
     // トークンは移らないので、ログインし直すまで未接続のまま並ぶ (#967)。
-    if (result.addedAccounts > 0) {
+    if (result.addedAccountKeys.isNotEmpty) {
       buffer.write(
-        '。${result.addedAccounts} 件のアカウントを追加しました'
+        '。${result.addedAccountKeys.length} 件のアカウントを追加しました'
         '（未接続。ログインし直すと使えます）',
       );
     }
@@ -244,6 +247,26 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
 
   /// 取り込んだ値を画面へ反映する (#857)。
   ///
+  /// 取り込んだアカウントを実行中の一覧へ出す (#1001)。
+  ///
+  /// ⚠ **索引を書いただけでは画面に出ない。**`restoreSessions` は起動時に 1 度
+  /// だけ索引を読むので、これが無いと「n 件のアカウントを追加しました」と言い
+  /// ながら次の起動まで現れない（Codex P2 / PR #1002）。
+  void _hydrateImportedAccounts(SettingsImportResult result) {
+    if (result.addedAccountKeys.isEmpty) return;
+
+    final keys = <AccountKey>[];
+    for (final raw in result.addedAccountKeys) {
+      try {
+        keys.add(AccountKey.fromStorageKey(raw));
+      } catch (_) {
+        // 取り込み側が parse 済みなので通常は来ない。保険。
+        continue;
+      }
+    }
+    ref.read(accountManagerProvider.notifier).addDisconnectedAccounts(keys);
+  }
+
   /// **[exportableSettings] と 1:1 で対応させること。**ここに足し忘れると、
   /// 値は書き込まれているのに次の起動まで画面へ出ない。
   void _refreshPreferenceProviders() {

--- a/packages/capsicum/lib/src/ui/util/settings_backup_apply.dart
+++ b/packages/capsicum/lib/src/ui/util/settings_backup_apply.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../model/account_key.dart';
+import '../../provider/account_manager_provider.dart';
+import '../../provider/preferences_provider.dart';
+import '../../service/settings_backup.dart';
+
+/// 取り込んだバックアップを**実行中のアプリへ反映する** (#1001)。
+///
+/// ⚠ **呼び出し側が 2 つあるので、ここに寄せる**（Codex P2 / PR #1002）。設定画面
+/// （ログイン後）とサーバー選択画面（ログイン前）の両方から取り込めるが、片方に
+/// しか反映処理が無いと「読み込んだのに変わらない」が**その画面でだけ**起きる。
+/// 実際 2 巡目のレビューで、ログイン前の経路が providers も account manager も
+/// 触っていないことを指摘された。
+///
+/// やることは 2 つ:
+///
+/// 1. **設定の反映** … 各 Notifier は `build()` で prefs を読み直すので、
+///    invalidate すれば画面が新しい設定で組み直される（再起動を求めない）。
+///    ⚠ ログイン前でも要る — `themeModeProvider` / `fontScaleProvider` は
+///    `main.dart` が既に読んでおり、放っておくとプロセスが終わるまで古い値のまま。
+/// 2. **アカウントの反映** … 索引を書いただけでは画面に出ない。`restoreSessions`
+///    は起動時に 1 度しか索引を読まないので、足したぶんを「未接続」として積む
+///    （[AccountManagerNotifier.addDisconnectedAccounts]）。
+void applyImportedSettingsBackup(WidgetRef ref, SettingsImportResult result) {
+  for (final provider in backedUpPreferenceProviders) {
+    ref.invalidate(provider);
+  }
+
+  if (result.addedAccountKeys.isEmpty) return;
+
+  final keys = <AccountKey>[];
+  for (final raw in result.addedAccountKeys) {
+    try {
+      keys.add(AccountKey.fromStorageKey(raw));
+    } catch (_) {
+      // 取り込み側が正規形へ直したうえで積んでいるので通常は来ない。保険。
+      continue;
+    }
+  }
+  ref.read(accountManagerProvider.notifier).addDisconnectedAccounts(keys);
+}

--- a/packages/capsicum/test/account_manager_add_disconnected_test.dart
+++ b/packages/capsicum/test/account_manager_add_disconnected_test.dart
@@ -1,0 +1,101 @@
+import 'package:capsicum/src/model/account_key.dart';
+import 'package:capsicum/src/model/offline_account.dart';
+import 'package:capsicum/src/provider/account_manager_provider.dart';
+import 'package:capsicum_backends/capsicum_backends.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #1001: 設定バックアップの取り込みで索引へ足したアカウントを、**再起動を
+/// 待たずに**「未接続」として一覧へ出す。
+///
+/// ⚠ **これが無いと「n 件のアカウントを追加しました」が嘘になる。**索引は
+/// `restoreSessions` が起動時に 1 度だけ読むので、実行中に足しても次の起動まで
+/// 画面に出ない（Codex P2 / PR #1002）。
+void main() {
+  const alice = AccountKey(
+    type: BackendType.mastodon,
+    host: 'mstdn.example',
+    username: 'alice',
+  );
+  const bob = AccountKey(
+    type: BackendType.misskey,
+    host: 'misskey.example',
+    username: 'bob',
+  );
+
+  AccountManagerNotifier notifierOf(ProviderContainer container) =>
+      container.read(accountManagerProvider.notifier);
+
+  ProviderContainer containerWith(AccountManagerState state) {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    // build() を走らせてから差し替える（Notifier は state の初期化が要る）。
+    container.read(accountManagerProvider);
+    notifierOf(container).state = state;
+    return container;
+  }
+
+  test('未接続として一覧へ足す', () {
+    final container = containerWith(const AccountManagerState());
+
+    notifierOf(container).addDisconnectedAccounts([alice, bob]);
+
+    final offline = container.read(accountManagerProvider).offlineAccounts;
+    expect(offline.map((o) => o.key), [alice, bob]);
+    expect(
+      offline.every((o) => o.reason == OfflineAccountReason.secretMissing),
+      isTrue,
+      reason: 'トークンが無いので probe を組み立てられない＝再試行の対象にしない',
+    );
+  });
+
+  // ⚠ **背景リトライへ回さない。**トークンが無いので回しても永久に失敗する。
+  test('再試行の対象にしない', () {
+    final container = containerWith(const AccountManagerState());
+
+    notifierOf(container).addDisconnectedAccounts([alice]);
+
+    final offline = container
+        .read(accountManagerProvider)
+        .offlineAccounts
+        .first;
+    expect(offline.recoverableByRetry, isFalse);
+  });
+
+  // 取り込みは**マージ**であって置き換えではない。
+  test('既にオフラインで居るアカウントは触らない', () {
+    final container = containerWith(
+      const AccountManagerState(
+        offlineAccounts: [OfflineAccount(key: alice, retrying: true)],
+      ),
+    );
+
+    notifierOf(container).addDisconnectedAccounts([alice, bob]);
+
+    final offline = container.read(accountManagerProvider).offlineAccounts;
+    expect(offline.length, 2);
+    expect(
+      offline.first.reason,
+      OfflineAccountReason.unreachable,
+      reason: '到達不能で待っている最中のものを未接続へ落とさない',
+    );
+    expect(offline.last.key, bob);
+  });
+
+  test('同じ key を 2 度足しても重複しない', () {
+    final container = containerWith(const AccountManagerState());
+
+    notifierOf(container).addDisconnectedAccounts([alice, alice]);
+
+    expect(container.read(accountManagerProvider).offlineAccounts.length, 1);
+  });
+
+  test('足すものが無ければ state を作り替えない', () {
+    final container = containerWith(const AccountManagerState());
+    final before = container.read(accountManagerProvider);
+
+    notifierOf(container).addDisconnectedAccounts(const []);
+
+    expect(identical(container.read(accountManagerProvider), before), isTrue);
+  });
+}

--- a/packages/capsicum/test/settings_backup_test.dart
+++ b/packages/capsicum/test/settings_backup_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// #857: 設定のバックアップの書き出し / 読み込み。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  _accountIndexTests();
 
   Future<SharedPreferences> prefsWith(Map<String, Object> values) async {
     SharedPreferences.setMockInitialValues(values);
@@ -30,16 +31,22 @@ void main() {
       expect(yaml, isNot(contains('theme_mode')));
     });
 
-    test('アカウント・認証情報は書かない', () async {
+    // ⚠ **#1001 で契約が変わった。**アカウント索引（host + username）は**書く**。
+    // 書かないのは**トークンと端末固有 ID**。索引を運ばないと移行先にアカウントが
+    // 1 件も生まれず、「未接続として並べてログインし直す」(#967) が始まらない。
+    test('トークンと端末固有 ID は書かない（索引は書く）', () async {
       final prefs = await prefsWith({
         'font_scale': 1.2,
-        'capsicum_account_keys_v2': '["mstdn.example_pooza"]',
+        'capsicum_account_keys_v2': '["mastodon://pooza@mstdn.example"]',
+        'secret_mastodon://pooza@mstdn.example': 'token-must-not-leak',
         'capsicum_device_install_id': 'device-abc',
       });
 
       final yaml = yamlOf(prefs);
 
-      expect(yaml, isNot(contains('account')));
+      expect(yaml, contains('- "mastodon://pooza@mstdn.example"'));
+      expect(yaml, isNot(contains('token-must-not-leak')));
+      expect(yaml, isNot(contains('secret_')));
       expect(yaml, isNot(contains('device')));
     });
 
@@ -197,6 +204,158 @@ settings:
           reason: '「$text」を設定として受けてはいけない',
         );
       }
+    });
+  });
+}
+
+/// #1001: アカウント索引（host + username・トークン無し）の書き出し / 取り込み。
+///
+/// ⚠ **「索引を運ぶ」と「未接続として並べる」で 1 つの筋書き**（#967）。トークン
+/// は平文 YAML に載せられない（ファイル 1 つの流出で全アカウントが乗っ取られる）
+/// ので、移行先では未接続として並び、ログインし直して初めて使える。索引が載って
+/// いなければ移行先にアカウントは 1 件も生まれず、「スマホと PC で同期する」は
+/// 成立しない。
+void _accountIndexTests() {
+  const accountListKey = 'capsicum_account_keys_v2';
+  const alice = 'mastodon://alice@mstdn.example';
+  const bob = 'misskey://bob@misskey.example';
+
+  Future<SharedPreferences> prefsWith(Map<String, Object> values) async {
+    SharedPreferences.setMockInitialValues(values);
+    return SharedPreferences.getInstance();
+  }
+
+  String yamlOf(SharedPreferences prefs) => buildSettingsBackupYaml(
+    prefs,
+    appVersion: '1.59.0+172',
+    exportedAt: '2026-08-22T12:00:00Z',
+  );
+
+  group('アカウント索引の書き出し (#1001)', () {
+    test('索引にあるアカウントを accounts: へ書く', () async {
+      final prefs = await prefsWith({accountListKey: '["$alice","$bob"]'});
+
+      final yaml = yamlOf(prefs);
+
+      expect(yaml, contains('accounts:'));
+      expect(yaml, contains('- "$alice"'));
+      expect(yaml, contains('- "$bob"'));
+    });
+
+    test('アカウントが無ければ accounts: 自体を書かない', () async {
+      final prefs = await prefsWith({'font_scale': 1.2});
+
+      expect(yamlOf(prefs), isNot(contains('accounts:')));
+    });
+
+    // ⚠ **秘匿値が混ざらないことの固定。**索引は host + username だけで、
+    // secret は secure storage 側にある（YAML には触れさせない）。
+    test('トークンらしき文字列は書かない', () async {
+      final prefs = await prefsWith({
+        accountListKey: '["$alice"]',
+        'secret_$alice': 'token-must-not-leak',
+      });
+
+      final yaml = yamlOf(prefs);
+
+      expect(yaml, isNot(contains('token-must-not-leak')));
+      expect(yaml, isNot(contains('secret_')));
+    });
+
+    test('壊れた索引 JSON では accounts: を書かない', () async {
+      final prefs = await prefsWith({accountListKey: '{壊れている'});
+
+      expect(yamlOf(prefs), isNot(contains('accounts:')));
+    });
+  });
+
+  group('アカウント索引の取り込み (#1001)', () {
+    String yamlWithAccounts(List<String> keys) => [
+      'version: 1',
+      'accounts:',
+      ...keys.map((k) => '  - "$k"'),
+      'settings:',
+      '  font_scale: 1.2',
+    ].join('\n');
+
+    test('索引へ足し、件数を返す', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts([alice, bob]),
+      );
+
+      expect(result.addedAccounts, 2);
+      expect(prefs.getString(accountListKey), contains(alice));
+      expect(prefs.getString(accountListKey), contains(bob));
+    });
+
+    // ⚠ **既存のアカウントを消さない。**移行先に既にアカウントが居ることが
+    // あり、置き換えると「読み込んだら手元のアカウントが消えた」になる。
+    test('既にあるアカウントを消さず、重複も作らない', () async {
+      final prefs = await prefsWith({accountListKey: '["$alice"]'});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts([alice, bob]),
+      );
+
+      expect(result.addedAccounts, 1, reason: 'bob だけが増える');
+      final saved = prefs.getString(accountListKey)!;
+      expect(saved, contains(alice));
+      expect(saved, contains(bob));
+      expect(alice.allMatches(saved).length, 1, reason: '重複させない');
+    });
+
+    // ⚠ **secret は触らない。**索引だけが増えるので未接続として並ぶ (#967)。
+    test('secret を作らない（未接続として並ぶ状態にする）', () async {
+      final prefs = await prefsWith({});
+
+      await applySettingsBackupYaml(prefs, yamlWithAccounts([alice]));
+
+      expect(prefs.getKeys().where((k) => k.startsWith('secret_')), isEmpty);
+    });
+
+    test('accounts: が無いファイルでも従来どおり読める', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        'version: 1\nsettings:\n  font_scale: 1.2\n',
+      );
+
+      expect(result.addedAccounts, 0);
+      expect(result.applied, contains('font_scale'));
+      expect(prefs.getString(accountListKey), isNull);
+    });
+
+    // 壊れた要素でファイル全体を捨てない（設定側と同じ方針）。
+    test('読めない要素は理由を残して飛ばす', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        'version: 1\naccounts:\n  - "壊れている"\n  - "$alice"\nsettings:\n'
+        '  font_scale: 1.2\n',
+      );
+
+      expect(result.addedAccounts, 1);
+      expect(result.skipped['accounts'], isNotNull);
+      expect(result.applied, contains('font_scale'));
+    });
+
+    test('accounts: が一覧でなければ理由を残して続行する', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        'version: 1\naccounts: "alice"\nsettings:\n  font_scale: 1.2\n',
+      );
+
+      expect(result.addedAccounts, 0);
+      expect(result.skipped['accounts'], isNotNull);
+      expect(result.applied, contains('font_scale'));
     });
   });
 }

--- a/packages/capsicum/test/settings_backup_test.dart
+++ b/packages/capsicum/test/settings_backup_test.dart
@@ -376,6 +376,24 @@ void _accountIndexTests() {
       expect(result.addedAccountKeys, [alice]);
     });
 
+    // ⚠ **parse が通っても中身が欠けていれば捨てる（Codex P2 / PR #1002）。**
+    // `AccountKey.fromStorageKey` は Uri.parse に乗っているだけなので
+    // `mastodon://alice` は host=alice / username='' として通り、正規形は
+    // `mastodon://@alice` になる。入れてしまうと**復帰できない未接続の行**を
+    // 作ったうえで「追加しました」と報告することになる。
+    test('username / host が欠けた key は取り込まない', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts(['mastodon://alice', 'mastodon://@mstdn.example']),
+      );
+
+      expect(result.addedAccountKeys, isEmpty);
+      expect(result.skipped['accounts'], isNotNull);
+      expect(prefs.getString(accountListKey), isNull);
+    });
+
     test('accounts: が一覧でなければ理由を残して続行する', () async {
       final prefs = await prefsWith({});
 

--- a/packages/capsicum/test/settings_backup_test.dart
+++ b/packages/capsicum/test/settings_backup_test.dart
@@ -286,7 +286,7 @@ void _accountIndexTests() {
         yamlWithAccounts([alice, bob]),
       );
 
-      expect(result.addedAccounts, 2);
+      expect(result.addedAccountKeys.length, 2);
       expect(prefs.getString(accountListKey), contains(alice));
       expect(prefs.getString(accountListKey), contains(bob));
     });
@@ -301,7 +301,7 @@ void _accountIndexTests() {
         yamlWithAccounts([alice, bob]),
       );
 
-      expect(result.addedAccounts, 1, reason: 'bob だけが増える');
+      expect(result.addedAccountKeys.length, 1, reason: 'bob だけが増える');
       final saved = prefs.getString(accountListKey)!;
       expect(saved, contains(alice));
       expect(saved, contains(bob));
@@ -325,7 +325,7 @@ void _accountIndexTests() {
         'version: 1\nsettings:\n  font_scale: 1.2\n',
       );
 
-      expect(result.addedAccounts, 0);
+      expect(result.addedAccountKeys, isEmpty);
       expect(result.applied, contains('font_scale'));
       expect(prefs.getString(accountListKey), isNull);
     });
@@ -340,7 +340,7 @@ void _accountIndexTests() {
         '  font_scale: 1.2\n',
       );
 
-      expect(result.addedAccounts, 1);
+      expect(result.addedAccountKeys.length, 1);
       expect(result.skipped['accounts'], isNotNull);
       expect(result.applied, contains('font_scale'));
     });
@@ -353,7 +353,7 @@ void _accountIndexTests() {
         'version: 1\naccounts: "alice"\nsettings:\n  font_scale: 1.2\n',
       );
 
-      expect(result.addedAccounts, 0);
+      expect(result.addedAccountKeys, isEmpty);
       expect(result.skipped['accounts'], isNotNull);
       expect(result.applied, contains('font_scale'));
     });

--- a/packages/capsicum/test/settings_backup_test.dart
+++ b/packages/capsicum/test/settings_backup_test.dart
@@ -345,6 +345,37 @@ void _accountIndexTests() {
       expect(result.applied, contains('font_scale'));
     });
 
+    // ⚠ **正規形にしてから保存する（Codex P2 / PR #1002）。**parse は通るが
+    // `toStorageKey()` と違う文字列（末尾スラッシュ等）をそのまま入れると、
+    // 接続し直した後に saveAccount が正規形を別行として足し、**同じアカウントが
+    // 「トークンあり」と「未接続」の 2 行に割れる**。
+    test('非正規形の key は正規形にして保存する', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts(['mastodon://alice@mstdn.example/']),
+      );
+
+      expect(result.addedAccountKeys, [alice]);
+      expect(prefs.getString(accountListKey), contains(alice));
+      expect(
+        prefs.getString(accountListKey),
+        isNot(contains('mstdn.example/')),
+      );
+    });
+
+    test('正規形と非正規形が両方あっても 1 件にまとめる', () async {
+      final prefs = await prefsWith({});
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts([alice, 'mastodon://alice@mstdn.example/']),
+      );
+
+      expect(result.addedAccountKeys, [alice]);
+    });
+
     test('accounts: が一覧でなければ理由を残して続行する', () async {
       final prefs = await prefsWith({});
 


### PR DESCRIPTION
#967 の残り半分。**「スマホと PC でアカウントを同期する」を成立させる**ための索引の運搬。

## なぜ要るか

#967 は「トークンが無いアカウントを**未接続として並べる**」を実装したが、**その状態を移行先で作る担当が居なかった**。書き出しに索引 `capsicum_account_keys_v2` が含まれないため、新しい端末で YAML を読み込んでもアカウントは 1 件も生まれない。結果、#967 が効くのは同じ端末で索引だけ生き残ったケース（再インストール / 端末復元 / Keystore リセット）に限られていた。

⚠ **トークンを運べないからこそ再接続が要る**、という筋書きなので、索引と #967 は対。片方だけでは移行が始まらない。

## 何を載せるか

`accounts:` に `AccountKey.toStorageKey()`（`mastodon://user@host`）の一覧。**host + username だけ**で、これは非秘匿値として SharedPreferences に置かれているもの（`AccountStorage` の doc に *"The list of account keys itself is non-sensitive"* と明記）。

⚠ **トークンは載せない**（#857 の方針は変えない）。平文 YAML に並ぶと、ファイル 1 つの流出で全アカウントが乗っ取られる。

## 取り込みの意味論

- **マージであって置き換えではない。** 移行先に既にアカウントが居ることがあるので、既存を消さず重複も作らない
- **secret には触らない。** 索引だけが増えるので、足したアカウントは未接続として並び、ログインし直すと復帰する（#967）
- 壊れた要素はファイル全体を捨てず、`skipped` に理由を積んで続行する（設定側と同じ方針）
- `prefs.setString` の戻り値を見る。⚠ 失敗しても throw しないので、無視すると「読み込んだのに増えていない」が無言になる（`AccountStorage` が踏んだのと同じ罠）

## 版は上げない

`accounts:` は任意キーなので `version: 1` のまま。旧版の capsicum は未知のトップレベルキーを読まないため壊れない。

## 文言

画面の説明・確認ダイアログ・取り込み結果を、アカウントが含まれること／未接続で並ぶことが伝わる形に直した。⚠ 結果表示は「**追加しました（未接続。ログインし直すと使えます）**」で止め、**使えるとは言わない**。

## 検証

- `flutter test` … 923 tests / All passed（新規 9 件）
- `dart analyze --fatal-infos` … No issues found
- `dart format` … 差分なし
- 新規テストで固定した契約: 索引を書く / トークンと端末固有 ID は書かない / 既存を消さず重複も作らない / secret を作らない / `accounts:` の無い旧ファイルも従来どおり読める / 壊れた要素は理由を残して飛ばす

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
