### PR TITLE
fix: ALT 編集の出し分けを版番号からモロヘイヤのフラグへ移す (#999)

### DIFF
--- a/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
@@ -134,11 +134,11 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
       supportsMediaUpdate: adapter is MediaUpdateSupport,
       needsMulukhiya: adapter is MastodonAdapter,
       hasMulukhiya: mulukhiya != null,
-      // ⚠ **版まで見る (#999)。**5.33.0 は media_update を受理するが補完しない
-      // ので、有無だけで出すと投稿から添付が全部外れ CW も消える。
-      mulukhiyaHandlesMediaUpdate: mulukhiyaSupportsMediaUpdate(
-        mulukhiya?.version,
-      ),
+      // ⚠ **フラグで見る (#999 / mulukhiya#4636)。**版番号では判定できない —
+      // 5.33.0 は補完せず投稿を壊し、5.34.0 は補完するが上流 PUT が 405 で失敗
+      // する。動く構成かどうかはモロヘイヤの ginseng ピン次第で、外からは
+      // `package.version` で区別できない。フラグを出さないサーバーでは出さない。
+      mulukhiyaHandlesMediaUpdate: mulukhiya?.mediaUpdateEnabled ?? false,
       isOwnPost: currentUser != null && currentUser.id == widget.postAuthorId,
       hasPostContext: widget.postAuthorId != null && widget.postId != null,
     );

--- a/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
@@ -117,8 +117,8 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   /// その API は「送らなかったパラメータ」を現状維持ではなく**空で更新**として
   /// 扱うため、素で呼ぶと **添付が全部外れ CW と閲覧注意も消える**
   /// （mulukhiya#4589）。現状維持すべき値を補完するのはモロヘイヤ 5.34.0 以降の
-  /// 役目なので、**5.34.0 未満の環境では導線ごと出さない**（有無だけでなく版も
-  /// 見る・#999）。
+  /// 役目なので、**モロヘイヤが `features.media_update` を名乗らない環境では
+  /// 導線ごと出さない**（#999 / mulukhiya#4636）。
   ///
   /// 判定を UI 層に置いているのは、アダプタからモロヘイヤの有無が見えないため
   /// （`MulukhiyaService` は `Account` が持つアプリ層の資産）。`TranslationSupport`

--- a/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
+++ b/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
@@ -1,26 +1,3 @@
-import '../../service/server_version_checker.dart';
-
-/// ALT 編集の PUT を安全に受けられる最小のモロヘイヤ版 (#999)。
-///
-/// これ未満のモロヘイヤは `X-Mulukhiya-Purpose: media_update` を**受理はする**が、
-/// 上流へ送る body が `{status, media_attributes}` だけで `media_ids` /
-/// `spoiler_text` / `sensitive` を補完しない（5.33.0 の `mastodon_controller.rb`）。
-/// nginx の `$status_put_backend` map は 5.33.0 にもあるので **405 では止まらず、
-/// 投稿から添付が全部外れ CW と閲覧注意も消える**。補完が入るのは 5.34.0 から。
-const kMulukhiyaMediaUpdateMinVersion = '5.34.0';
-
-/// モロヘイヤの版が ALT 編集の補完を持つか (#999)。[version] が null（モロヘイヤ
-/// 不在・版が読めない）なら false に倒す。**判定を誤ると投稿が壊れる側なので、
-/// 「分からない」は常に「出さない」に寄せる。**
-bool mulukhiyaSupportsMediaUpdate(String? version) {
-  if (version == null || version.isEmpty) return false;
-
-  return ServerVersionChecker.isAtLeast(
-    version,
-    kMulukhiyaMediaUpdateMinVersion,
-  );
-}
-
 /// 投稿済みメディアの説明（ALT）を編集する導線を出してよいか (#121)。
 ///
 /// ⚠ **間違えると投稿が壊れる判定なので、画面から切り出してテストで固定する。**

--- a/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
+++ b/packages/capsicum/lib/src/ui/util/attachment_description_edit.dart
@@ -36,8 +36,12 @@ bool mulukhiyaSupportsMediaUpdate(String? version) {
 /// - [needsMulukhiya] … その API がモロヘイヤの補完を前提にするか（Mastodon は
 ///   true、Misskey は `drive/files/update` が投稿済みでも効くので false）
 /// - [hasMulukhiya] … 現在のアカウントのサーバーにモロヘイヤがいるか
-/// - [mulukhiyaHandlesMediaUpdate] … そのモロヘイヤが**補完を持つ版**か
-///   （5.34.0 以降。[mulukhiyaSupportsMediaUpdate] で判定する・#999）
+/// - [mulukhiyaHandlesMediaUpdate] … そのモロヘイヤが `features.media_update` を
+///   名乗っているか（#999 / mulukhiya#4636）。⚠ **版番号では判定しない** — 動く
+///   かどうかはモロヘイヤが刺している ginseng-fediverse の版で決まり、
+///   `package.version` からは区別できない（5.33.0 は補完せず投稿を壊し、5.34.0 は
+///   補完するが上流 PUT が 405 で失敗する。どちらも「5.3x」としか名乗らない）。
+///   フラグを出さないサーバーでは false ＝ **導線を出さない**
 /// - [isOwnPost] … 自分の投稿か（他人の添付は編集できない）
 /// - [hasPostContext] … 投稿 id と投稿者 id が揃っているか。メディアビューアは
 ///   投稿を伴わない経路からも開くため、揃わないことがある

--- a/packages/capsicum/test/alt_edit_gate_source_test.dart
+++ b/packages/capsicum/test/alt_edit_gate_source_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #999: ALT 編集の出し分けが**モロヘイヤのフラグ**を見ているかの検査。
+///
+/// ⚠ **判定そのものは純関数のテストで固定できるが、「画面が何を渡しているか」は
+/// 固定できない。**実際、版判定からフラグ判定へ移した最初のコミットで
+/// `canEditAttachmentDescription` の doc と定数だけ差し替わり、**呼び出し側は版
+/// 判定のまま**残った（Codex P1 / PR #1004）。純関数のテストは bool を直接渡すので
+/// 素通りする。
+///
+/// 誤る側の代償が大きいので（5.33.0 なら投稿から添付が全部外れ CW も消える、
+/// 5.34.0 なら 405 で失敗する）、**入力の出どころ**をソースで固定する。
+/// widget test にしないのは、メディアビューアが投稿の文脈・アダプタ・アカウントを
+/// 揃えないと開けず、「出さない」側の分岐を組むのに実質フルスタックが要るため。
+void main() {
+  String mediaViewerSource() =>
+      File('lib/src/ui/screen/media_viewer_screen.dart').readAsStringSync();
+
+  test('mulukhiyaHandlesMediaUpdate にはフラグを渡す', () {
+    expect(
+      mediaViewerSource(),
+      contains(
+        'mulukhiyaHandlesMediaUpdate: mulukhiya?.mediaUpdateEnabled ?? false',
+      ),
+      reason:
+          'features.media_update を名乗るサーバーでだけ導線を出す'
+          '（mulukhiya#4636）',
+    );
+  });
+
+  // ⚠ **版番号は判定材料にしない。**動くかどうかはモロヘイヤが刺している
+  // ginseng-fediverse の版で決まり、`package.version` からは区別できない。
+  test('版番号で出し分けない', () {
+    final source = mediaViewerSource();
+
+    expect(
+      source,
+      isNot(contains('mulukhiyaSupportsMediaUpdate')),
+      reason: '版判定のヘルパーは削除済み。復活したらここで落とす',
+    );
+    expect(
+      source,
+      isNot(contains('mulukhiya?.version')),
+      reason: '5.34.0 は補完するが 405 で失敗する＝版では安全性を判定できない',
+    );
+  });
+}

--- a/packages/capsicum/test/attachment_description_edit_test.dart
+++ b/packages/capsicum/test/attachment_description_edit_test.dart
@@ -52,29 +52,27 @@ void main() {
     });
   });
 
-  group('モロヘイヤの版判定 (#999)', () {
-    test('5.34.0 以降は補完を持つ', () {
-      expect(mulukhiyaSupportsMediaUpdate('5.34.0'), isTrue);
-      expect(mulukhiyaSupportsMediaUpdate('5.34.1'), isTrue);
-      expect(mulukhiyaSupportsMediaUpdate('6.0.0'), isTrue);
-    });
-
-    test('5.34.0 未満は持たない', () {
-      expect(mulukhiyaSupportsMediaUpdate('5.33.0'), isFalse);
-      expect(mulukhiyaSupportsMediaUpdate('5.9.0'), isFalse);
+  // ⚠ **版番号では判定しない (#999 / mulukhiya#4636)。**動く構成かどうかは
+  // モロヘイヤが刺している ginseng-fediverse の版で決まり、`package.version` から
+  // は区別できない:
+  //
+  // - 5.33.0 … `media_update` を受理するが `media_ids` / `spoiler_text` /
+  //   `sensitive` を補完しない → **投稿から添付が全部外れ CW も消える**
+  // - 5.34.0 … 補完はするが上流 PUT に `X-Mulukhiya` が付かず **405 で失敗**
+  //   （ginseng-fediverse#254 / 1.8.30 で修正・5.35.0 に載る）
+  //
+  // どちらも外からは「5.3x」としか名乗らないので、モロヘイヤ側のフラグを見る。
+  group('モロヘイヤのフラグ判定 (#999)', () {
+    test('フラグを名乗らないサーバーでは出さない', () {
       expect(
-        mulukhiyaSupportsMediaUpdate('5.33.99'),
+        can(mulukhiyaHandlesMediaUpdate: false),
         isFalse,
-        reason: 'minor が下なら patch がいくつでも未満',
+        reason: '5.33.0 なら投稿が壊れ、5.34.0 なら 405 で失敗する',
       );
     });
 
-    // ⚠ **「分からない」は「出さない」に倒す。**判定を誤る側の代償が
-    // 「投稿が壊れる」なので、版が読めないときに通してはいけない。
-    test('版が無い・読めないときは出さない', () {
-      expect(mulukhiyaSupportsMediaUpdate(null), isFalse);
-      expect(mulukhiyaSupportsMediaUpdate(''), isFalse);
-      expect(mulukhiyaSupportsMediaUpdate('unknown'), isFalse);
+    test('フラグを名乗るサーバーでだけ出す', () {
+      expect(can(mulukhiyaHandlesMediaUpdate: true), isTrue);
     });
   });
 

--- a/packages/capsicum_backends/lib/src/mulukhiya/service.dart
+++ b/packages/capsicum_backends/lib/src/mulukhiya/service.dart
@@ -444,6 +444,22 @@ class MulukhiyaService {
   /// 開ける。旧モロヘイヤ (フラグ未提供) は false にフォールバックする。
   final bool mediaCatalogEnabled;
 
+  /// `features.media_update` フラグ (mulukhiya#4636 / capsicum#999)。`true` の
+  /// サーバーは **投稿済みメディアの ALT 編集を安全に処理できる**構成（#4589 の
+  /// 補完 + #4621 の修正 + ginseng-fediverse 1.8.30 以降のピン）。
+  ///
+  /// ⚠ **版番号では判定できないのでフラグで判定する。**Mastodon には投稿済み
+  /// 添付の説明だけを変える API が無く、投稿の更新 API を使うしかない。その API
+  /// は送らなかったパラメータを**空で更新**として扱うため、補完の無いモロヘイヤ
+  /// （5.33.0）へ投げると**投稿から添付が全部外れ CW と閲覧注意も消える**。
+  /// 一方 5.34.0 は補完はするが上流 PUT に `X-Mulukhiya` が付かず 405 で失敗する。
+  /// **どちらも `package.version` からは区別できない**（動くかどうかはモロヘイヤ
+  /// が刺している ginseng-fediverse の版で決まる）。
+  ///
+  /// 旧モロヘイヤ（フラグ未提供）は false にフォールバックし、**導線を出さない**。
+  /// 「分からない」を「出さない」へ倒すのは、誤る側の代償が投稿の破壊だから。
+  final bool mediaUpdateEnabled;
+
   /// `features.announcement_push` フラグ (#477)。`true` のサーバーは capsicum-relay
   /// が `/api/v1/announcements` (または Misskey 相当) を polling して push を発火
   /// する経路に対応している。capsicum 側は probing 結果に基づき設定 UI のスイッチを
@@ -535,6 +551,7 @@ class MulukhiyaService {
     this.annictLinked = true,
     this.annictReviewEnabled = false,
     this.mediaCatalogEnabled = false,
+    this.mediaUpdateEnabled = false,
     this.announcementPushEnabled = false,
     this.wordSuggestEnabled = false,
     this.nowplayingResolverEnabled = false,
@@ -616,6 +633,7 @@ class MulukhiyaService {
         annictLinked: features?['annict_linked'] != false,
         annictReviewEnabled: features?['annict_review'] == true,
         mediaCatalogEnabled: features?['media_catalog'] == true,
+        mediaUpdateEnabled: features?['media_update'] == true,
         announcementPushEnabled: features?['announcement_push'] == true,
         wordSuggestEnabled: features?['word_suggest'] == true,
         nowplayingResolverEnabled: features?['nowplaying_resolver'] == true,


### PR DESCRIPTION
版番号では判定できないことが分かったので、`features.media_update`（mulukhiya#4636・5.35.0）へ移す。

- **5.33.0** … 補完せず上流へ届く＝**投稿が壊れる**（添付が外れ CW も消える）
- **5.34.0** … 補完するが上流 PUT に `X-Mulukhiya` が付かず **405**（mulukhiya#4621 / ginseng-fediverse#254 → 1.8.30 → 5.35.0）

⚠ **5.34.0 は修正を含まないままリリース予定**なので、版ゲートのままだと本番が 5.34.0 へ上がった瞬間に「出るが押すと失敗する」導線が開く。動くかどうかはモロヘイヤの ginseng ピン次第で、`package.version` からは区別できない。

フラグを出さないサーバーでは false ＝ 導線を出さない（「分からない」は「出さない」へ倒す）。

`flutter test` 912 tests / All passed、`dart analyze --fatal-infos` No issues。

Refs #999 / mulukhiya#4636

🤖 Generated with [Claude Code](https://claude.com/claude-code)