### PR TITLE
fix: Misskey で ALT を空にできるようにする (#1005)

### DIFF
--- a/packages/capsicum_backends/lib/src/misskey/adapter.dart
+++ b/packages/capsicum_backends/lib/src/misskey/adapter.dart
@@ -682,16 +682,23 @@ class MisskeyAdapter extends DecentralizedBackendAdapter
 
   // MediaUpdateSupport
 
+  /// ⚠ **空文字は「消す」であって「変更なし」ではない (#1005)。**
+  /// [MisskeyClient.updateDriveFile] は null をキーごと省略するので、空文字を
+  /// null に変換して渡すと body が `{fileId}` だけになり、Misskey 側で更新対象が
+  /// 空になって **500** になる（＝「更新に失敗しました」）。しかも仮に通っても
+  /// 省略は「変更なし」なので **ALT を消せない**。明示的な null を送る経路
+  /// （[MisskeyClient.clearDriveFileComment]）へ分ける。
   @override
   Future<void> updateAttachmentDescription(
     String mediaId,
     String description, {
     required String postId,
   }) async {
-    await client.updateDriveFile(
-      mediaId,
-      comment: description.isNotEmpty ? description : null,
-    );
+    if (description.isEmpty) {
+      await client.clearDriveFileComment(mediaId);
+      return;
+    }
+    await client.updateDriveFile(mediaId, comment: description);
   }
 
   // LoginSupport

--- a/packages/capsicum_backends/lib/src/misskey/client.dart
+++ b/packages/capsicum_backends/lib/src/misskey/client.dart
@@ -352,6 +352,16 @@ class MisskeyClient {
   }
 
   /// POST /api/drive/files/update
+  /// ⚠ **null は「変更しない」。**Misskey は**キーの省略**を「変更なし」、
+  /// **明示的な null** を「消す」として扱う。ここは null-aware element で省略
+  /// するので、値を**消したい**ときは [clearDriveFileComment] のように明示的な
+  /// null を載せる経路を使う（`moveDriveFile` が folderId で同じ理由の迂回を
+  /// している）。
+  ///
+  /// ⚠ **更新対象が 1 つも無い body を送らない (#1005)。**Misskey の
+  /// `DriveService.updateFile` は受け取った値をそのまま
+  /// `driveFilesRepository.update` へ渡すため、**全部 undefined だと TypeORM が
+  /// 落ちて 500 になる**。呼び出し側で「何も変えない呼び出し」を作らないこと。
   Future<MisskeyDriveFile> updateDriveFile(
     String fileId, {
     String? comment,
@@ -366,6 +376,20 @@ class MisskeyClient {
         'name': ?name,
         'folderId': ?folderId,
       }),
+    );
+    return MisskeyDriveFile.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// ALT（`comment`）を消す (#1005)。
+  ///
+  /// ⚠ **[updateDriveFile] では消せない。**あちらは null を「変更しない」として
+  /// キーごと省略するので、空文字を null に変換して渡すと body が `{fileId}` だけ
+  /// になり、**Misskey 側で更新対象が空になって 500** になる（それが #1005 の
+  /// 症状）。消すには**明示的な null** を送る必要がある。
+  Future<MisskeyDriveFile> clearDriveFileComment(String fileId) async {
+    final response = await dio.post(
+      '/api/drive/files/update',
+      data: createBody({'fileId': fileId, 'comment': null}),
     );
     return MisskeyDriveFile.fromJson(response.data as Map<String, dynamic>);
   }

--- a/packages/capsicum_backends/test/misskey_alt_clear_test.dart
+++ b/packages/capsicum_backends/test/misskey_alt_clear_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:capsicum_backends/capsicum_backends.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+/// #1005: Misskey で ALT を空にすると「更新に失敗しました」になり、そもそも
+/// 消せなかった。
+///
+/// ⚠ **Misskey はキーの省略を「変更なし」、明示的な null を「消す」として扱う。**
+/// 空文字を null に変換して [MisskeyClient.updateDriveFile] へ渡すと、null-aware
+/// element がキーごと省略するため body が `{fileId}` だけになり、Misskey 側は
+/// `driveFilesRepository.update` に**空の更新**を渡して 500 で落ちる。
+///
+/// ここで固定するのは**送信 body の形**。「消す」と「変更なし」が取り違えられて
+/// いないことは、これを見ないと分からない（症状は「更新に失敗しました」の 1 行）。
+class _CapturingAdapter implements HttpClientAdapter {
+  Map<String, dynamic>? lastBody;
+  String? lastPath;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastPath = options.path;
+    final data = options.data;
+    lastBody = data is Map<String, dynamic> ? data : null;
+    return ResponseBody.fromString(
+      jsonEncode({
+        'id': 'file1',
+        'name': 'image.png',
+        'type': 'image/png',
+        'isSensitive': false,
+      }),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  group('MisskeyAdapter.updateAttachmentDescription (#1005)', () {
+    late MisskeyAdapter adapter;
+    late _CapturingAdapter http;
+
+    setUp(() async {
+      adapter = await MisskeyAdapter.create('misskey.example');
+      http = _CapturingAdapter();
+      adapter.client.dio.httpClientAdapter = http;
+    });
+
+    test('空文字なら comment: null を明示的に送る（消す）', () async {
+      await adapter.updateAttachmentDescription('file1', '', postId: 'note1');
+
+      expect(http.lastPath, contains('drive/files/update'));
+      expect(
+        http.lastBody!.containsKey('comment'),
+        isTrue,
+        reason: 'キーを省略すると Misskey は「変更なし」と解釈し、ALT を消せない',
+      );
+      expect(http.lastBody!['comment'], isNull);
+    });
+
+    // ⚠ **これが 500 の実体。**更新対象が 1 つも無い body を送ると、Misskey の
+    // DriveService.updateFile が空の更新を TypeORM へ渡して落ちる。
+    test('空文字でも fileId だけの body にしない', () async {
+      await adapter.updateAttachmentDescription('file1', '', postId: 'note1');
+
+      final keys = http.lastBody!.keys.where((k) => k != 'i').toSet();
+      expect(keys, {'fileId', 'comment'});
+    });
+
+    test('非空ならその文字列を送る', () async {
+      await adapter.updateAttachmentDescription(
+        'file1',
+        '猫の写真',
+        postId: 'note1',
+      );
+
+      expect(http.lastBody!['comment'], '猫の写真');
+    });
+
+    // 変更しないキーまで送らない（省略＝変更なしを利用する側の契約）。
+    test('name / folderId は送らない', () async {
+      await adapter.updateAttachmentDescription(
+        'file1',
+        '猫の写真',
+        postId: 'note1',
+      );
+
+      expect(http.lastBody!.containsKey('name'), isFalse);
+      expect(http.lastBody!.containsKey('folderId'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
メディアビューアから ALT を**空文字にして保存**すると「更新に失敗しました」になり、**そもそも ALT を消せなかった**（dev27 で確認）。

## 原因

キー省略と明示的 null の取り違え。

1. `MisskeyAdapter` が空文字を null へ変換
2. `MisskeyClient.updateDriveFile` は `'comment': ?comment` で **null のときキーごと省略**
3. body が `{i, fileId}` だけになる
4. Misskey はキー省略を「変更なし」と解釈 → **消せない**。さらに `DriveService.updateFile` が空の更新を TypeORM へ渡して **500**

⚠ **同じ罠は `moveDriveFile` が folderId で既に踏んでおり**、そこだけ `updateDriveFile` を迂回して直接 POST していた。ALT 側にその考慮が無かった。

## 直し方

`clearDriveFileComment`（明示的な `comment: null` を送る）を足し、空文字の経路を分けた。`updateDriveFile` 側にも「null は変更しない」「更新対象が空の body を作らない」を doc として残した。

## 検証

送信 body を捕まえるテストで固定（空文字 → `comment: null` を明示的に送る / `fileId` だけの body にしない / 非空はその文字列 / name・folderId は送らない）。`flutter test` 164 tests / All passed、`dart analyze --fatal-infos` No issues。

⚠ **実サーバーでの往復は dev27 で目視待ち。**

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)