### PR TITLE
fix: v1.59 リリース前レビューの赤 3 件と黄 5 件を消化する

### DIFF
--- a/packages/capsicum/lib/src/provider/account_manager_provider.dart
+++ b/packages/capsicum/lib/src/provider/account_manager_provider.dart
@@ -955,7 +955,12 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
       // 読むと StateError を投げるので、評価順が逆だと打ち切りの周回で落ちる。
       // prod では provider がアプリ寿命なので実害は薄いが、テストと将来の
       // autoDispose 化で効く。
-      while (!_disposed && state.offlineAccounts.isNotEmpty) {
+      // ⚠ **継続条件も `recoverableByRetry` で絞る (#1011)。**起動判定 (#967) と
+      // probe 対象だけを絞っていたため、到達不能分が復帰 / 降格して**未接続だけ
+      // が残る**と、probe 0 件のループがプロセスの終わりまで空回りしていた
+      // （起動判定のコメントが警告している状態に、別経路で到達できていた）。
+      while (!_disposed &&
+          state.offlineAccounts.any((o) => o.recoverableByRetry)) {
         final delay = offlineRetryDelay(attempt);
         await Future<void>.delayed(delay);
         if (_disposed) return;
@@ -978,7 +983,12 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
         // 上の節目。#792 はここで打ち切っていたが、#938 で継続へ変えたので
         // 「打ち切り」ではなく marker として 1 度だけ記録する。per-process
         // dedup があるので、以降の周回では二重に上がらない。
-        final remaining = state.offlineAccounts;
+        // ⚠ **marker の母数も同じ絞り (#1011)。**未接続は「待っても戻らない」
+        // ので、「ramp-up を使い切っても到達不能」の観測に混ぜると #792 / #938
+        // の指標が汚れる。
+        final remaining = state.offlineAccounts
+            .where((o) => o.recoverableByRetry)
+            .toList(growable: false);
         if (attempt == kOfflineRetryRampUp.length && remaining.isNotEmpty) {
           debugPrint(
             'capsicum: restoreSessions: ${remaining.length} account(s) still '
@@ -1002,7 +1012,8 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
   /// オフライン中はアプリを閉じていることも多いので、この契機がいちばん効く。
   /// 復元済み / オフライン無しなら何もしない。
   void refreshOfflineRestoresOnResume() {
-    if (state.offlineAccounts.isEmpty) return;
+    // 未接続しか無ければ probe する相手が居ない (#1011)。
+    if (!state.offlineAccounts.any((o) => o.recoverableByRetry)) return;
     unawaited(retryOfflineRestores());
   }
 

--- a/packages/capsicum/lib/src/service/compose_draft_store.dart
+++ b/packages/capsicum/lib/src/service/compose_draft_store.dart
@@ -40,6 +40,23 @@ class ComposeDraft {
   bool get hasText => text.isNotEmpty;
 }
 
+/// 下書きの書き込みが拒まれた (#1011)。
+///
+/// `SharedPreferences` の setter は失敗しても投げず false を返すので、ここで
+/// 例外へ翻訳する。**意図的な no-op（破棄済み・世代ズレ）と同じ null にしない**
+/// ため — 呼び出し側が区別できないと、失敗が観測も通知もされないまま古い保存
+/// 時刻が表示に残る（Codex P2 / PR #1013）。
+///
+/// ⚠ **メッセージに本文を載せない。** Sentry へ出る。
+class ComposeDraftSaveException implements Exception {
+  const ComposeDraftSaveException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'ComposeDraftSaveException: $message';
+}
+
 /// 投稿フォームのローカル自動保存の永続化 (#966 / #964)。
 ///
 /// UI から切り離してあるのは、「破棄したあとは書き戻さない」という副作用の順序
@@ -115,9 +132,13 @@ class ComposeDraftStore {
   /// さらに、**別インスタンスが [clear] してスロットの世代が進んでいたら**書き
   /// 戻さない (#969)。
   ///
-  /// 保存した時刻を返す（画面の「自動保存 12:34」に使う）。no-op だった場合と
-  /// **書き込みに失敗した場合**は null (#1011)。⚠ **時刻は呼び出し側が渡す** — `DateTime.now()` を内部で呼ぶと
-  /// テストで固定できない。
+  /// 保存した時刻を返す（画面の「自動保存 12:34」に使う）。**意図的な no-op**
+  /// （破棄済み・世代ズレ）では null。⚠ **時刻は呼び出し側が渡す** —
+  /// `DateTime.now()` を内部で呼ぶとテストで固定できない。
+  ///
+  /// ⚠ **書き込みが拒まれたら [ComposeDraftSaveException] を投げる (#1011)。**
+  /// null と混ぜると、呼び出し側が「意図した no-op」と区別できず、失敗が観測も
+  /// 通知もされないまま**古い保存時刻が表示に残る**（Codex P2 / PR #1013）。
   Future<DateTime?> save(ComposeDraft draft, {required DateTime now}) async {
     if (_discarded) return null;
     final prefs = await SharedPreferences.getInstance();
@@ -129,6 +150,7 @@ class ComposeDraftStore {
     // ⚠ **書けたかどうかを見る (#1011)。**`setString` 等は失敗しても throw せず
     // false を返す。捨てていたため、**書けていないのに画面へ「自動保存 12:34」**
     // が出ていた。ユーザーはそれを信じてアプリを終了し、本文を失う。
+    // 拒否は下で例外へ翻訳する（意図的な no-op と同じ null にしない）。
     var ok = true;
     ok = await prefs.setString(_k(textKey), draft.text) && ok;
     ok = await prefs.setString(_k(cwTextKey), draft.cwText) && ok;
@@ -145,7 +167,12 @@ class ComposeDraftStore {
     }
     // 世代印は書き込みの成否と別（このスロットに触った事実は変わらない）。
     _syncedGeneration = current;
-    return ok ? now : null;
+    if (!ok) {
+      throw const ComposeDraftSaveException(
+        'shared preferences rejected write',
+      );
+    }
+    return now;
   }
 
   /// 保存済みの入力を読む。何も保存されていなければ null。

--- a/packages/capsicum/lib/src/service/compose_draft_store.dart
+++ b/packages/capsicum/lib/src/service/compose_draft_store.dart
@@ -115,8 +115,8 @@ class ComposeDraftStore {
   /// さらに、**別インスタンスが [clear] してスロットの世代が進んでいたら**書き
   /// 戻さない (#969)。
   ///
-  /// 保存した時刻を返す（画面の「自動保存 12:34」に使う）。no-op だった場合は
-  /// null。⚠ **時刻は呼び出し側が渡す** — `DateTime.now()` を内部で呼ぶと
+  /// 保存した時刻を返す（画面の「自動保存 12:34」に使う）。no-op だった場合と
+  /// **書き込みに失敗した場合**は null (#1011)。⚠ **時刻は呼び出し側が渡す** — `DateTime.now()` を内部で呼ぶと
   /// テストで固定できない。
   Future<DateTime?> save(ComposeDraft draft, {required DateTime now}) async {
     if (_discarded) return null;
@@ -126,20 +126,26 @@ class ComposeDraftStore {
     // 進めていたら、こちらの書き戻しは stale なので捨てる。まだ同期していない
     // （null）場合は現世代を採用して通常どおり保存する。
     if (_syncedGeneration != null && _syncedGeneration != current) return null;
-    await prefs.setString(_k(textKey), draft.text);
-    await prefs.setString(_k(cwTextKey), draft.cwText);
-    await prefs.setBool(_k(cwEnabledKey), draft.cwEnabled);
-    await prefs.setInt(_k(attachmentCountKey), draft.attachmentCount);
-    await prefs.setBool(_k(sensitiveKey), draft.sensitive);
-    await prefs.setBool(_k(localOnlyKey), draft.localOnly);
-    await prefs.setString(_k(savedAtKey), now.toIso8601String());
+    // ⚠ **書けたかどうかを見る (#1011)。**`setString` 等は失敗しても throw せず
+    // false を返す。捨てていたため、**書けていないのに画面へ「自動保存 12:34」**
+    // が出ていた。ユーザーはそれを信じてアプリを終了し、本文を失う。
+    var ok = true;
+    ok = await prefs.setString(_k(textKey), draft.text) && ok;
+    ok = await prefs.setString(_k(cwTextKey), draft.cwText) && ok;
+    ok = await prefs.setBool(_k(cwEnabledKey), draft.cwEnabled) && ok;
+    ok =
+        await prefs.setInt(_k(attachmentCountKey), draft.attachmentCount) && ok;
+    ok = await prefs.setBool(_k(sensitiveKey), draft.sensitive) && ok;
+    ok = await prefs.setBool(_k(localOnlyKey), draft.localOnly) && ok;
+    ok = await prefs.setString(_k(savedAtKey), now.toIso8601String()) && ok;
     if (draft.scope != null) {
-      await prefs.setString(_k(scopeKey), draft.scope!.name);
+      ok = await prefs.setString(_k(scopeKey), draft.scope!.name) && ok;
     } else {
       await prefs.remove(_k(scopeKey));
     }
+    // 世代印は書き込みの成否と別（このスロットに触った事実は変わらない）。
     _syncedGeneration = current;
-    return now;
+    return ok ? now : null;
   }
 
   /// 保存済みの入力を読む。何も保存されていなければ null。

--- a/packages/capsicum/lib/src/service/compose_draft_store.dart
+++ b/packages/capsicum/lib/src/service/compose_draft_store.dart
@@ -239,15 +239,31 @@ class ComposeDraftStore {
   /// これで、true のままだと [discarded] を戻す手段が無く、`late final` の
   /// ストアを持つその画面の自動保存が**二度と効かない**（取消のあとに書いた
   /// 本文が黙って失われる）。
-  Future<void> clear({bool discard = true}) async {
+  /// 完全に永続化できたかを返す。false は「拒まれた書き込みがある」＝ **次の
+  /// 起動で消したはずの本文が戻りうる**という意味 (Codex P2 / PR #1013)。
+  /// 呼び出し側は観測に残す。投げないのは、投稿成功の直後にも通る経路で、
+  /// ここで投げると**投稿は通っているのに失敗と伝える**ことになるため。
+  Future<bool> clear({bool discard = true}) async {
     if (discard) _discarded = true;
     final prefs = await SharedPreferences.getInstance();
     final next = (prefs.getInt(_k(generationKey)) ?? 0) + 1;
-    await prefs.setInt(_k(generationKey), next);
+    final advanced = await prefs.setInt(_k(generationKey), next);
     // 世代を進めた当人なので、自分の印も進める。放っておくと世代ガード (#969)
     // が**自分自身の**以降の保存を stale と見て捨てる。
+    //
+    // ⚠ **書き込みが拒まれても進める。**`SharedPreferences` は setter の結果に
+    // 関わらず**プロセス内のキャッシュを先に更新する**（`_setValue` は
+    // `_preferenceCache[key] = value` してからストアを呼ぶ）ので、拒否されても
+    // このプロセスの `getInt` は新しい世代を返す。ここで印を据え置くと、以降の
+    // [save] が毎回「世代ズレ」の no-op になり、**取消のあとの本文が黙って
+    // 保存されない**（#1008 と同じ症状が別経路で戻る）。永続化の失敗は戻り値で
+    // 伝える。
     if (!discard) _syncedGeneration = next;
-    await _removeAll(prefs, _k);
+    var removed = true;
+    for (final base in _allKeys) {
+      removed = await prefs.remove(_k(base)) && removed;
+    }
+    return advanced && removed;
   }
 
   /// アカウント削除時にそのスロットを掃除する (#964)。放っておくと孤児キーが

--- a/packages/capsicum/lib/src/service/compose_draft_store.dart
+++ b/packages/capsicum/lib/src/service/compose_draft_store.dart
@@ -198,13 +198,22 @@ class ComposeDraftStore {
   ///
   /// 世代を進めるので、重ねて開いている別画面の [save]（古い本文の書き戻し）が
   /// 以降無効になる (#969)。世代印そのものは残す。
-  Future<void> clear() async {
-    _discarded = true;
+  ///
+  /// [discard] は「**このインスタンスの以降の保存も止めるか**」。既定の true は
+  /// 投稿成功・サーバー下書き保存向けで、どちらも直後に画面を閉じる。
+  ///
+  /// ⚠ **画面に留まったまま消す経路は false で呼ぶ (#1008)。**復元の「取消」が
+  /// これで、true のままだと [discarded] を戻す手段が無く、`late final` の
+  /// ストアを持つその画面の自動保存が**二度と効かない**（取消のあとに書いた
+  /// 本文が黙って失われる）。
+  Future<void> clear({bool discard = true}) async {
+    if (discard) _discarded = true;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(
-      _k(generationKey),
-      (prefs.getInt(_k(generationKey)) ?? 0) + 1,
-    );
+    final next = (prefs.getInt(_k(generationKey)) ?? 0) + 1;
+    await prefs.setInt(_k(generationKey), next);
+    // 世代を進めた当人なので、自分の印も進める。放っておくと世代ガード (#969)
+    // が**自分自身の**以降の保存を stale と見て捨てる。
+    if (!discard) _syncedGeneration = next;
     await _removeAll(prefs, _k);
   }
 

--- a/packages/capsicum/lib/src/service/settings_backup.dart
+++ b/packages/capsicum/lib/src/service/settings_backup.dart
@@ -380,6 +380,16 @@ Future<List<String>> _mergeAccounts(
 
   final existing = readAccountKeysForBackup(prefs);
   final merged = [...existing];
+  // ⚠ **突き合わせは正規形どうしで (#1011)。**取り込む側は正規形なのに、索引側は
+  // 生のまま（`readAccountKeysForBackup` は parse できるかを見るだけ）だったので、
+  // 索引に非正規形が入っている端末では `contains` が外れて**同じアカウントが 2 行
+  // に割れる**。ホストを大文字混じりで打って作ったアカウントで踏む。
+  // ⚠ **索引そのものは直さない。**`secret_<key>` は生の key で引くので、ここで
+  // 書き換えるとトークンとの対応が切れる。比較用の集合だけ正規形にする。
+  final canonical = existing
+      .map(_canonicalAccountKey)
+      .whereType<String>()
+      .toSet();
   final added = <String>[];
   var invalid = 0;
   for (final entry in node) {
@@ -390,7 +400,7 @@ Future<List<String>> _mergeAccounts(
       invalid++;
       continue;
     }
-    if (merged.contains(key)) continue;
+    if (!canonical.add(key)) continue;
     merged.add(key);
     added.add(key);
   }

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -1113,17 +1113,23 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
         error: e,
         stackTrace: st,
       );
-      // 打鍵のたびに走るので、1 画面 1 回だけ伝える。
-      if (mounted && !_draftSaveFailureNotified) {
-        _draftSaveFailureNotified = true;
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('下書きを保存できませんでした')));
+      if (mounted) {
+        // ⚠ **表示も下ろす (#1011 / Codex P2)。**「自動保存 12:34」を残すと、
+        // 直近の本文まで保存されているように読める。
+        setState(() => _draftSavedAt = null);
+        // 打鍵のたびに走るので、1 画面 1 回だけ伝える。
+        if (!_draftSaveFailureNotified) {
+          _draftSaveFailureNotified = true;
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('下書きを保存できませんでした')));
+        }
       }
       return;
     }
-    // 世代ガード (#969)・破棄済み・書き込み失敗 (#1011) では null。表示を更新
-    // すると「保存された」と嘘をつくので、返ってきたときだけ反映する (#964)。
+    // 世代ガード (#969) や破棄済みの no-op では null（書き込みの拒否はここには
+    // 来ない — 上の catch で扱う）。表示を更新すると「保存された」と嘘をつくので、
+    // 返ってきたときだけ反映する (#964)。
     if (savedAt != null && mounted) setState(() => _draftSavedAt = savedAt);
   }
 

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -427,6 +427,10 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   /// 走るので、同じ snackbar を出し続けない。
   bool _draftSaveFailureNotified = false;
 
+  /// 進行中の取消の消去 (Codex P2 / PR #1013)。[_saveDraft] はこれを待ってから
+  /// 書く。**保存と消去が並行に走ると、消去が保存直後の本文を消す。**
+  Future<void>? _draftClearing;
+
   /// 復元した下書きを画面に書き戻したか (#964)。true の間だけ「前回の入力を
   /// 復元しました／取消」のバナーを出す。**復元されたことも伝わっていない**
   /// のが「わかりづらい」のもう半分の原因だった。
@@ -1061,7 +1065,12 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
       _draftRestoredNotice = false;
       _draftSavedAt = null;
     });
-    unawaited(_clearDraft(discard: false));
+    // ⚠ **消去の完了を握っておく (Codex P2 / PR #1013)。**取消の直後に背面化
+    // / 離脱すると、ライフサイクルと PopScope の保存がこの消去と**並行**に走る。
+    // 消去は世代を進めてから全キーを消すので、間に入った保存の本文をそのまま
+    // 消しうる。[_saveDraft] は最初にこれを待って直列化する。
+    _draftClearing = _clearDraft(discard: false);
+    unawaited(_draftClearing);
   }
 
   /// 入力停止から [_draftDebounce] 後に自動保存する (#964)。打鍵のたびに
@@ -1083,6 +1092,17 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   /// No-op for reply / quote / redraft / shared / initial-text sessions.
   Future<void> _saveDraft() async {
     if (!_draftAutoSave || !_draftRestored) return;
+    // 取消の消去と直列化する。⚠ **消去の失敗はここで報告しない** — 保存の
+    // 失敗として出すと原因を取り違える。
+    final clearing = _draftClearing;
+    if (clearing != null) {
+      try {
+        await clearing;
+      } catch (_) {
+        // 消去できていなくても、この後の保存は独立に試みる。
+      }
+      if (!mounted) return;
+    }
     // **ストアへ渡す値は await をまたぐ前に確定させる。** 画面を離れる経路
     // (#966) ではこの直後に State が dispose され、`_controller` も dispose
     // 済みになる。await の後で読むと破棄済み ChangeNotifier に触れて落ちる。
@@ -1205,8 +1225,23 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   /// Remove any persisted draft (called after a successful post).
   /// [discard] は「以降の自動保存も止めるか」。既定 true で画面を閉じる経路向け
   /// （[ComposeDraftStore.clear] の doc を参照）。取消だけ false (#1008)。
-  Future<void> _clearDraft({bool discard = true}) =>
-      _draftStore.clear(discard: discard);
+  ///
+  /// 永続化できなかったぶんは観測に残す (Codex P2 / PR #1013)。ユーザーには
+  /// 出さない — **この時点では実害が無い**（消えていないだけ）で、次に開いた
+  /// ときに古い下書きが復元されて初めて見える。投稿直後にも通る経路なので、
+  /// ここで snackbar を出すと「投稿は成功しているのに失敗したように読める」。
+  Future<void> _clearDraft({bool discard = true}) async {
+    final persisted = await _draftStore.clear(discard: discard);
+    if (persisted) return;
+    reportOpFailure(
+      tagKey: 'compose.op',
+      operation: 'draft_clear',
+      error: const ComposeDraftSaveException(
+        'shared preferences rejected clear',
+      ),
+      stackTrace: StackTrace.current,
+    );
+  }
 
   void _initReplyMentions(Post replyTo) {
     final currentUser = ref.read(currentAccountProvider)?.user;

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -423,6 +423,10 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   /// 入力欄の下に「自動保存 12:34」として常時出す。
   DateTime? _draftSavedAt;
 
+  /// 保存の失敗をこの画面で 1 度でも伝えたか (#1011)。自動保存は打鍵のたびに
+  /// 走るので、同じ snackbar を出し続けない。
+  bool _draftSaveFailureNotified = false;
+
   /// 復元した下書きを画面に書き戻したか (#964)。true の間だけ「前回の入力を
   /// 復元しました／取消」のバナーを出す。**復元されたことも伝わっていない**
   /// のが「わかりづらい」のもう半分の原因だった。
@@ -1082,22 +1086,44 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
     // **ストアへ渡す値は await をまたぐ前に確定させる。** 画面を離れる経路
     // (#966) ではこの直後に State が dispose され、`_controller` も dispose
     // 済みになる。await の後で読むと破棄済み ChangeNotifier に触れて落ちる。
-    final savedAt = await _draftStore.save(
-      ComposeDraft(
-        text: _controller.text,
-        cwText: _cwController.text,
-        cwEnabled: _cwEnabled,
-        attachmentCount: _attachments.length,
-        // 設定値も保存する (#964)。本文だけ戻して公開範囲が既定に戻ると、
-        // 気づかず広い範囲へ投げる事故になる。
-        scope: _scope,
-        sensitive: _sensitiveEnabled,
-        localOnly: _localOnly,
-      ),
-      now: DateTime.now(),
-    );
-    // 世代ガード (#969) や破棄済みで no-op だったときは null。表示を更新すると
-    // 「保存された」と嘘をつくので、返ってきたときだけ反映する (#964)。
+    final DateTime? savedAt;
+    try {
+      savedAt = await _draftStore.save(
+        ComposeDraft(
+          text: _controller.text,
+          cwText: _cwController.text,
+          cwEnabled: _cwEnabled,
+          attachmentCount: _attachments.length,
+          // 設定値も保存する (#964)。本文だけ戻して公開範囲が既定に戻ると、
+          // 気づかず広い範囲へ投げる事故になる。
+          scope: _scope,
+          sensitive: _sensitiveEnabled,
+          localOnly: _localOnly,
+        ),
+        now: DateTime.now(),
+      );
+    } catch (e, st) {
+      // ⚠ **握り潰さない (#1011)。**保存が投げると本文を失うのに、投げっぱなしの
+      // 呼び出し（ライフサイクル / PopScope / debounce）なので未処理の非同期
+      // エラーとして Sentry に出るだけで、画面には何も出ていなかった。復元側
+      // ([_restoreDraft]) は最初から catch している。
+      reportOpFailure(
+        tagKey: 'compose.op',
+        operation: 'draft_save',
+        error: e,
+        stackTrace: st,
+      );
+      // 打鍵のたびに走るので、1 画面 1 回だけ伝える。
+      if (mounted && !_draftSaveFailureNotified) {
+        _draftSaveFailureNotified = true;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('下書きを保存できませんでした')));
+      }
+      return;
+    }
+    // 世代ガード (#969)・破棄済み・書き込み失敗 (#1011) では null。表示を更新
+    // すると「保存された」と嘘をつくので、返ってきたときだけ反映する (#964)。
     if (savedAt != null && mounted) setState(() => _draftSavedAt = savedAt);
   }
 

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -1092,8 +1092,28 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   /// No-op for reply / quote / redraft / shared / initial-text sessions.
   Future<void> _saveDraft() async {
     if (!_draftAutoSave || !_draftRestored) return;
-    // 取消の消去と直列化する。⚠ **消去の失敗はここで報告しない** — 保存の
-    // 失敗として出すと原因を取り違える。
+    // **ストアへ渡す値は await をまたぐ前に確定させる。** 画面を離れる経路
+    // (#966) ではこの直後に State が dispose され、`_controller` も dispose
+    // 済みになる。await の後で読むと破棄済み ChangeNotifier に触れて落ちる。
+    // ⚠ **消去待ちより前で取る (Codex P2 / PR #1013)。**待ってから読むと、
+    // 離脱時保存が「待っている間に dispose された」で捨てられる — それが唯一の
+    // 保存機会なので、取消のあとに書いた本文がそのまま消える。
+    final draft = ComposeDraft(
+      text: _controller.text,
+      cwText: _cwController.text,
+      cwEnabled: _cwEnabled,
+      attachmentCount: _attachments.length,
+      // 設定値も保存する (#964)。本文だけ戻して公開範囲が既定に戻ると、
+      // 気づかず広い範囲へ投げる事故になる。
+      scope: _scope,
+      sensitive: _sensitiveEnabled,
+      localOnly: _localOnly,
+    );
+
+    // 取消の消去と直列化する (Codex P2 / PR #1013)。並行に走ると、消去の
+    // 全キー削除がいま保存した本文を消す。⚠ **消去の失敗はここで報告しない** —
+    // 保存の失敗として出すと原因を取り違える。⚠ **dispose 済みでも続ける** —
+    // 控えた値はもう手元にあるので、書き切ることが離脱時保存の役目。
     final clearing = _draftClearing;
     if (clearing != null) {
       try {
@@ -1101,27 +1121,11 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
       } catch (_) {
         // 消去できていなくても、この後の保存は独立に試みる。
       }
-      if (!mounted) return;
     }
-    // **ストアへ渡す値は await をまたぐ前に確定させる。** 画面を離れる経路
-    // (#966) ではこの直後に State が dispose され、`_controller` も dispose
-    // 済みになる。await の後で読むと破棄済み ChangeNotifier に触れて落ちる。
+
     final DateTime? savedAt;
     try {
-      savedAt = await _draftStore.save(
-        ComposeDraft(
-          text: _controller.text,
-          cwText: _cwController.text,
-          cwEnabled: _cwEnabled,
-          attachmentCount: _attachments.length,
-          // 設定値も保存する (#964)。本文だけ戻して公開範囲が既定に戻ると、
-          // 気づかず広い範囲へ投げる事故になる。
-          scope: _scope,
-          sensitive: _sensitiveEnabled,
-          localOnly: _localOnly,
-        ),
-        now: DateTime.now(),
-      );
+      savedAt = await _draftStore.save(draft, now: DateTime.now());
     } catch (e, st) {
       // ⚠ **握り潰さない (#1011)。**保存が投げると本文を失うのに、投げっぱなしの
       // 呼び出し（ライフサイクル / PopScope / debounce）なので未処理の非同期

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -1037,6 +1037,10 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   ///
   /// ⚠ **保存スロットも消す。** 戻したのに次に開いてまた同じものが復元されると、
   /// 「取消」が効いていないように見える。
+  ///
+  /// ⚠ **ただし自動保存は止めない (#1008)。** 他の [_clearDraft] 呼び出しは直後に
+  /// 画面を閉じるが、取消だけはこの画面に留まる。破棄済みにすると、取消のあとに
+  /// 書いた本文が保存されないまま失われる。
   void _undoDraftRestore() {
     final before = _draftBeforeRestore;
     _draftDebounceTimer?.cancel();
@@ -1053,7 +1057,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
       _draftRestoredNotice = false;
       _draftSavedAt = null;
     });
-    unawaited(_clearDraft());
+    unawaited(_clearDraft(discard: false));
   }
 
   /// 入力停止から [_draftDebounce] 後に自動保存する (#964)。打鍵のたびに
@@ -1167,7 +1171,10 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
   }
 
   /// Remove any persisted draft (called after a successful post).
-  Future<void> _clearDraft() => _draftStore.clear();
+  /// [discard] は「以降の自動保存も止めるか」。既定 true で画面を閉じる経路向け
+  /// （[ComposeDraftStore.clear] の doc を参照）。取消だけ false (#1008)。
+  Future<void> _clearDraft({bool discard = true}) =>
+      _draftStore.clear(discard: discard);
 
   void _initReplyMentions(Post replyTo) {
     final currentUser = ref.read(currentAccountProvider)?.user;

--- a/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
@@ -150,40 +150,17 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
     // 上書き**してしまう（同じ画像が 2 枚並ぶ形で呼び出し側にも渡る）。
     final index = _currentIndex;
     final attachment = _attachments[index];
-    final controller = TextEditingController(
-      text: attachment.description ?? '',
-    );
 
-    final String? result;
-    try {
-      result = await showDialog<String>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('メディアの説明を編集'),
-          content: TextField(
-            controller: controller,
-            maxLines: 4,
-            decoration: const InputDecoration(
-              hintText: '説明を入力…',
-              border: OutlineInputBorder(),
-            ),
-            autofocus: true,
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('キャンセル'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.pop(context, controller.text),
-              child: const Text('保存'),
-            ),
-          ],
-        ),
-      );
-    } finally {
-      controller.dispose();
-    }
+    // controller はダイアログ自身に持たせる (Codex P2 / PR #1013)。`showDialog`
+    // の Future は**閉じるアニメーションの完了より前に**解決するので、呼び出し側
+    // で await の直後に破棄すると、まだツリーに残っている `TextField` が
+    // 破棄済み controller に触れる（autofocus でキーボードが開いていると、
+    // 閉じる途中のフォーカス更新で踏む）。
+    final result = await showDialog<String>(
+      context: context,
+      builder: (_) =>
+          _DescriptionEditDialog(initialText: attachment.description ?? ''),
+    );
 
     if (result == null || !mounted) return;
 
@@ -563,6 +540,54 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
 /// 横ドラッグを掴んでしまい、「画像の上でしか反応しない／ドラッグだと渋い」
 /// 感触の一因になっていた）。ズーム中のみ pan を有効化し、併せて
 /// [onZoomChanged] で親にズーム状態を通知して PageView のスワイプを止める。
+/// 投稿済みメディアの説明 (ALT) を編集するダイアログ (#121)。
+///
+/// ⚠ **controller の寿命をルートに合わせるために StatefulWidget にしている**
+/// (Codex P2 / PR #1013)。`showDialog` の Future は閉じるアニメーションの完了
+/// より前に解決するため、呼び出し側で破棄すると早すぎる。
+class _DescriptionEditDialog extends StatefulWidget {
+  const _DescriptionEditDialog({required this.initialText});
+
+  final String initialText;
+
+  @override
+  State<_DescriptionEditDialog> createState() => _DescriptionEditDialogState();
+}
+
+class _DescriptionEditDialogState extends State<_DescriptionEditDialog> {
+  late final _controller = TextEditingController(text: widget.initialText);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('メディアの説明を編集'),
+    content: TextField(
+      controller: _controller,
+      maxLines: 4,
+      decoration: const InputDecoration(
+        hintText: '説明を入力…',
+        border: OutlineInputBorder(),
+      ),
+      autofocus: true,
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: const Text('キャンセル'),
+      ),
+      FilledButton(
+        onPressed: () => Navigator.pop(context, _controller.text),
+        child: const Text('保存'),
+      ),
+    ],
+  );
+}
+
 class _ZoomableImagePage extends StatefulWidget {
   final Widget child;
   final ValueChanged<bool> onZoomChanged;

--- a/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/media_viewer_screen.dart
@@ -145,36 +145,45 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   }
 
   Future<void> _editDescription() async {
-    final attachment = _attachments[_currentIndex];
+    // ⚠ **添付と位置は開く前に確定させる (#1011)。**書き戻し先を「その時点の
+    // `_currentIndex`」にすると、保存中にページを送っただけで**別の添付の枠へ
+    // 上書き**してしまう（同じ画像が 2 枚並ぶ形で呼び出し側にも渡る）。
+    final index = _currentIndex;
+    final attachment = _attachments[index];
     final controller = TextEditingController(
       text: attachment.description ?? '',
     );
 
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('メディアの説明を編集'),
-        content: TextField(
-          controller: controller,
-          maxLines: 4,
-          decoration: const InputDecoration(
-            hintText: '説明を入力…',
-            border: OutlineInputBorder(),
+    final String? result;
+    try {
+      result = await showDialog<String>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('メディアの説明を編集'),
+          content: TextField(
+            controller: controller,
+            maxLines: 4,
+            decoration: const InputDecoration(
+              hintText: '説明を入力…',
+              border: OutlineInputBorder(),
+            ),
+            autofocus: true,
           ),
-          autofocus: true,
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, controller.text),
+              child: const Text('保存'),
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('キャンセル'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: const Text('保存'),
-          ),
-        ],
-      ),
-    );
+      );
+    } finally {
+      controller.dispose();
+    }
 
     if (result == null || !mounted) return;
 
@@ -188,22 +197,33 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
         result,
         postId: widget.postId!,
       );
-      setState(() {
-        _attachments[_currentIndex] = Attachment(
-          id: attachment.id,
-          type: attachment.type,
-          url: attachment.url,
-          previewUrl: attachment.previewUrl,
-          description: result,
-        );
-        _modified = true;
-      });
+      // ⚠ **`setState` にも mounted を見る (#1011)。**破棄済みだと下の catch へ
+      // 落ちて、**サーバー側は成功しているのに失敗扱い**になる。
       if (mounted) {
+        setState(() {
+          _attachments[index] = Attachment(
+            id: attachment.id,
+            type: attachment.type,
+            url: attachment.url,
+            previewUrl: attachment.previewUrl,
+            description: result,
+          );
+          _modified = true;
+        });
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('説明を更新しました')));
       }
-    } catch (e) {
+    } catch (e, st) {
+      // 同ファイルの他の操作と同じく件数を残す (#1011)。⚠ **フラグが true でも
+      // 失敗する窓が残っている** — 上流の PUT が 405 / 500 で落ちる構成があり
+      // （mulukhiya#4621）、ユーザーには理由不明の 1 行しか出ない。
+      reportOpFailure(
+        tagKey: 'media.op',
+        operation: 'alt_edit',
+        error: e,
+        stackTrace: st,
+      );
       if (mounted) {
         ScaffoldMessenger.of(
           context,

--- a/packages/capsicum/lib/src/ui/screen/profile_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/profile_screen.dart
@@ -20,6 +20,7 @@ import '../widget/content_parser.dart';
 import '../widget/emoji_text.dart';
 import '../widget/page_card.dart';
 import '../widget/post_tile.dart';
+import '../widget/report_comment_dialog.dart';
 import '../widget/user_avatar.dart';
 import '../util/user_acct.dart';
 import '../util/relative_time.dart';
@@ -1536,55 +1537,26 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
     if (adapter is! ReportSupport) return;
     // await をまたいで context を触らないよう、messenger は先に取る。
     final messenger = ScaffoldMessenger.of(context);
-    final commentController = TextEditingController();
+    // controller の寿命はダイアログ側が持つ (Codex P2 / PR #1013)。ここで
+    // `finally` 破棄すると、閉じるアニメーションの途中で `TextField` が破棄済み
+    // controller に触れる。文面以外は投稿の通報と同じなので widget ごと共通。
+    final comment = await showReportCommentDialog(
+      context,
+      message: '@${widget.user.username} をサーバー管理者に通報しますか？',
+    );
+    if (comment == null) return;
+
     try {
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (dialogContext) => AlertDialog(
-          title: const Text('通報'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text('@${widget.user.username} をサーバー管理者に通報しますか？'),
-              const SizedBox(height: 12),
-              TextField(
-                controller: commentController,
-                decoration: const InputDecoration(
-                  hintText: '理由（任意）',
-                  border: OutlineInputBorder(),
-                ),
-                maxLines: 3,
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext, false),
-              child: const Text('キャンセル'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext, true),
-              child: const Text('通報'),
-            ),
-          ],
-        ),
+      // try の中では `is!` ガードの型昇格が効かないため明示キャストする。
+      // `post_tile.dart` の `_confirmReport` も同じ形。
+      await (adapter as ReportSupport).reportUser(
+        widget.user.id,
+        comment: comment.isNotEmpty ? comment : null,
       );
-      if (confirmed != true) return;
-      final comment = commentController.text.trim();
-      try {
-        // try の中では `is!` ガードの型昇格が効かないため明示キャストする。
-        // `post_tile.dart` の `_confirmReport` も同じ形。
-        await (adapter as ReportSupport).reportUser(
-          widget.user.id,
-          comment: comment.isNotEmpty ? comment : null,
-        );
-        messenger.showSnackBar(const SnackBar(content: Text('通報しました')));
-      } catch (e) {
-        debugLogException('User report error', e);
-        messenger.showSnackBar(const SnackBar(content: Text('通報に失敗しました')));
-      }
-    } finally {
-      commentController.dispose();
+      messenger.showSnackBar(const SnackBar(content: Text('通報しました')));
+    } catch (e) {
+      debugLogException('User report error', e);
+      messenger.showSnackBar(const SnackBar(content: Text('通報に失敗しました')));
     }
   }
 

--- a/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/server_selection_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:capsicum_backends/capsicum_backends.dart';
 import 'package:dio/dio.dart';
 import 'package:file_selector/file_selector.dart';
@@ -10,9 +8,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../constants.dart';
 import '../../model/account_key.dart';
-import '../../preset_servers.dart';
-import '../../service/settings_backup.dart';
 import '../../platform/platform_info.dart';
+import '../../preset_servers.dart';
+import '../../service/sentry_op_failure.dart';
+import '../../service/settings_backup.dart';
 import '../../url_helper.dart';
 import '../../util/exception_scrub.dart';
 import '../util/settings_backup_apply.dart';
@@ -64,13 +63,20 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
     );
     if (file == null || !mounted) return;
 
+    // ⚠ **ログイン前でも確認を挟む (#1010)。** この画面は新しい端末専用ではなく、
+    // ドロワーの「アカウントを追加」と未接続の「接続し直す」からも開くので、
+    // **設定を持っている端末**から押されうる。上書きは元に戻せない。
+    if (!await confirmSettingsBackupImport(context) || !mounted) return;
+
     setState(() {
       _importing = true;
       _error = null;
     });
     final messenger = ScaffoldMessenger.of(context);
     try {
-      final text = await File(file.path).readAsString();
+      // 設定画面側と同じ読み方に揃える (#1010)。`XFile` の抽象を剥がすと、
+      // path を持たない実装が来たときにこちらだけ壊れる。
+      final text = await file.readAsString();
       final prefs = await SharedPreferences.getInstance();
       final result = await applySettingsBackupYaml(prefs, text);
       if (!mounted) return;
@@ -79,6 +85,9 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
       // 取り込んだアカウントも次の起動まで一覧に出ない。ログイン後の経路と
       // 同じヘルパーを通す。
       applyImportedSettingsBackup(ref, result);
+      // 取り込めなかったキーの観測も両画面で揃える (#1010)。移行の主経路は
+      // こちら（新しい端末＝ログイン前）なので、ここが落ちていると分布が偏る。
+      reportSettingsBackupImportSkips(result);
 
       final hosts = <String>[];
       for (final raw in result.addedAccountKeys) {
@@ -96,20 +105,39 @@ class _ServerSelectionScreenState extends ConsumerState<ServerSelectionScreen> {
           _hostController.text = hosts.first;
         }
       });
+      // ⚠ **但し書きを落とさない (#1010)。** 索引の保存に失敗すると skipped に
+      // だけ残って追加 0 件になるので、これが無いと部分失敗が無言になる。
+      final note = settingsBackupSkippedNote(result);
       messenger.showSnackBar(
         SnackBar(
           content: Text(
             hosts.isEmpty
-                ? '設定を読み込みました'
+                ? '設定を読み込みました$note'
                 : '設定と ${result.addedAccountKeys.length} 件のアカウントを読み込みました。'
-                      'ログインすると使えるようになります',
+                      'ログインすると使えるようになります$note',
           ),
         ),
       );
-    } on SettingsBackupFormatException catch (e) {
+    } on SettingsBackupFormatException catch (e, st) {
+      // 失敗率の観測も設定画面側と揃える (#968 / #1010)。**例外の message は
+      // 載せない** — yaml のエラー文にファイルの行断片（＝設定値）が混じる。
+      reportOpFailure(
+        tagKey: 'settings_backup.op',
+        operation: 'import',
+        error: StateError('settings backup: unparseable / incompatible file'),
+        stackTrace: st,
+        tags: {'reason': 'format', 'entry': 'pre_login'},
+      );
       if (!mounted) return;
       messenger.showSnackBar(SnackBar(content: Text(e.message)));
-    } catch (e) {
+    } catch (e, st) {
+      reportOpFailure(
+        tagKey: 'settings_backup.op',
+        operation: 'import',
+        error: e,
+        stackTrace: st,
+        tags: {'entry': 'pre_login'},
+      );
       if (!mounted) return;
       messenger.showSnackBar(SnackBar(content: Text('読み込めませんでした: $e')));
     } finally {

--- a/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/settings/settings_backup_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -127,28 +126,9 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
     final file = await openFile(acceptedTypeGroups: [_typeGroup]);
     if (file == null || !mounted) return; // キャンセル
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('設定を読み込む'),
-        content: const Text(
-          'この端末の設定が、ファイルの内容で上書きされます。\n'
-          'ファイルに入っているアカウントは一覧へ追加されます'
-          '（この端末の既存のアカウントは消えません）。よろしいですか？',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('キャンセル'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('読み込む'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true || !mounted) return;
+    // 確認・skip の記録・但し書きはログイン前の経路と共通 (#1010)。
+    final confirmed = await confirmSettingsBackupImport(context);
+    if (!confirmed || !mounted) return;
 
     setState(() => _busy = true);
     final messenger = ScaffoldMessenger.of(context);
@@ -165,7 +145,7 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
       // 設定とアカウントの反映は共通ヘルパーへ寄せてある（ログイン前の経路と
       // 割れないようにするため・Codex P2 / PR #1002）。
       applyImportedSettingsBackup(ref, result);
-      _reportImportSkips(result);
+      reportSettingsBackupImportSkips(result);
       messenger.showSnackBar(SnackBar(content: Text(_importSummary(result))));
     } on SettingsBackupFormatException catch (e, st) {
       // 不正 YAML / 版違い / 設定ファイルでない、の失敗率を観測する (#968)。
@@ -197,32 +177,6 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
     }
   }
 
-  /// 取り込まなかったキーの内訳を Sentry へ残す (#968)。
-  ///
-  /// 画面には件数しか出ず記録も残らないため、版をまたいで互換が崩れても（未知の
-  /// キー・型違い・範囲外が増えても）気付けなかった。**キー名と理由だけ**を載せ、
-  /// **値は載せない**（テンプレート履歴・フォント名などが入るため）。失敗ではなく
-  /// 分布観測なので captureMessage（info）で、fingerprint は 1 本に集約する。
-  void _reportImportSkips(SettingsImportResult result) {
-    if (result.skipped.isEmpty) return;
-    try {
-      Sentry.captureMessage(
-        'settings_backup: import skipped ${result.skipped.length} keys',
-        level: SentryLevel.info,
-        withScope: (scope) {
-          scope.setTag('settings_backup.op', 'import_skip');
-          // key -> 理由。値は含めない（result.skipped は key→理由 の対応）。
-          scope.setContexts('settings_backup_skipped', {
-            for (final entry in result.skipped.entries) entry.key: entry.value,
-          });
-          scope.fingerprint = ['settings_backup.op', 'import_skip'];
-        },
-      );
-    } catch (_) {
-      // Sentry 失敗で UI を止めない。
-    }
-  }
-
   String _importSummary(SettingsImportResult result) {
     if (result.applied.isEmpty &&
         result.skipped.isEmpty &&
@@ -238,14 +192,10 @@ class _SettingsBackupScreenState extends ConsumerState<SettingsBackupScreen> {
         '（未接続。ログインし直すと使えます）',
       );
     }
-    if (result.skipped.isNotEmpty) {
-      buffer.write('（${result.skipped.length} 件は取り込みませんでした）');
-    }
+    buffer.write(settingsBackupSkippedNote(result));
     return buffer.toString();
   }
 
-  /// 取り込んだ値を画面へ反映する (#857)。
-  ///
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/capsicum/lib/src/ui/util/settings_backup_apply.dart
+++ b/packages/capsicum/lib/src/ui/util/settings_backup_apply.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../../model/account_key.dart';
 import '../../provider/account_manager_provider.dart';
@@ -40,3 +42,72 @@ void applyImportedSettingsBackup(WidgetRef ref, SettingsImportResult result) {
   }
   ref.read(accountManagerProvider.notifier).addDisconnectedAccounts(keys);
 }
+
+/// 取り込みの前に必ず挟む確認 (#1010)。
+///
+/// ⚠ **ログイン前の経路でも要る。** `/server` は新しい端末だけの画面ではなく、
+/// ドロワーの「アカウントを追加」と未接続アカウントの「接続し直す」からも開く。
+/// つまり**設定を持っている端末**からも取り込みボタンを押せる。上書きを元に
+/// 戻す手段は無いので、確認も反映（[applyImportedSettingsBackup]）と同じく
+/// 両画面で共通にする。
+Future<bool> confirmSettingsBackupImport(BuildContext context) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: const Text('設定を読み込む'),
+      content: const Text(
+        'この端末の設定が、ファイルの内容で上書きされます。\n'
+        'ファイルに入っているアカウントは一覧へ追加されます'
+        '（この端末の既存のアカウントは消えません）。よろしいですか？',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('読み込む'),
+        ),
+      ],
+    ),
+  );
+  return confirmed == true;
+}
+
+/// 取り込まなかったキーの内訳を Sentry へ残す (#968)。
+///
+/// 画面には件数しか出ず記録も残らないため、版をまたいで互換が崩れても（未知の
+/// キー・型違い・範囲外が増えても）気付けなかった。**キー名と理由だけ**を載せ、
+/// **値は載せない**（テンプレート履歴・フォント名などが入るため）。失敗ではなく
+/// 分布観測なので captureMessage（info）で、fingerprint は 1 本に集約する。
+///
+/// ⚠ **こちらも両画面で共通** (#1010)。移行の主経路はログイン前なので、そこで
+/// 観測が落ちていると分布がログイン後の再取り込みに偏る。
+void reportSettingsBackupImportSkips(SettingsImportResult result) {
+  if (result.skipped.isEmpty) return;
+  try {
+    Sentry.captureMessage(
+      'settings_backup: import skipped ${result.skipped.length} keys',
+      level: SentryLevel.info,
+      withScope: (scope) {
+        scope.setTag('settings_backup.op', 'import_skip');
+        // key -> 理由。値は含めない（result.skipped は key→理由 の対応）。
+        scope.setContexts('settings_backup_skipped', {
+          for (final entry in result.skipped.entries) entry.key: entry.value,
+        });
+        scope.fingerprint = ['settings_backup.op', 'import_skip'];
+      },
+    );
+  } catch (_) {
+    // Sentry 失敗で UI を止めない。
+  }
+}
+
+/// 取り込めなかった件数の但し書き。何も落ちていなければ空文字 (#1010)。
+///
+/// ⚠ **成功メッセージに必ず添える。** 索引の保存に失敗すると `skipped` にだけ
+/// 記録されて `addedAccountKeys` は空になるので、これが無いと「設定を読み込み
+/// ました」だけが出て**部分失敗が無言になる**。
+String settingsBackupSkippedNote(SettingsImportResult result) =>
+    result.skipped.isEmpty ? '' : '（${result.skipped.length} 件は取り込みませんでした）';

--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -33,6 +33,7 @@ import 'emoji_action_sheet.dart';
 import 'reaction_picker_sheet.dart';
 import 'home_menu.dart' show pickFollowedChannel;
 import 'post_touch_action_row.dart';
+import 'report_comment_dialog.dart';
 import 'user_avatar.dart';
 import 'emoji_text.dart';
 import '../../util/exception_scrub.dart';
@@ -1383,7 +1384,8 @@ class _PostTileState extends ConsumerState<PostTile> {
                   item(
                     leading: const Icon(Icons.flag_outlined),
                     title: const Text('通報'),
-                    onSelected: () => _confirmReport(context, targetPost),
+                    onSelected: () =>
+                        unawaited(_confirmReport(context, targetPost)),
                   ),
                 if (isOwn && adapter is PinSupport) ...[
                   const Divider(),
@@ -1524,64 +1526,35 @@ class _PostTileState extends ConsumerState<PostTile> {
     );
   }
 
-  void _confirmReport(BuildContext context, Post targetPost) {
+  Future<void> _confirmReport(BuildContext context, Post targetPost) async {
     final adapter = ref.read(currentAdapterProvider);
     if (adapter is! ReportSupport) return;
     final messenger = ScaffoldMessenger.of(context);
-    final commentController = TextEditingController();
-    // 理由は [_confirmDelete] の同名コメント (#1009)。この文面は builder の中に
-    // あるので、キーボードの開閉でダイアログが再ビルドされたときに投げる。
+    // 理由は [_confirmDelete] の同名コメント (#1009)。文面はダイアログを開く前に
+    // 組む（builder の中で `ref` を読むと、キーボードの開閉で再ビルドされたとき
+    // に dispose 済みで投げる）。
     final postLabel = ref.read(postLabelProvider);
 
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('通報'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 通報の宛先はアカウントで、投稿は証拠として添えるもの (#998)。
-            // Mastodon の `POST /api/v1/reports` は account_id が必須・
-            // status_ids が任意、Misskey の `report-abuse` に至っては投稿を
-            // 渡す口が無い。「投稿だけが通報された」と読める文面にしない。
-            Text(
-              'この$postLabelを添えて '
-              '@${targetPost.author.username} をサーバー管理者に通報しますか？',
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: commentController,
-              decoration: const InputDecoration(
-                hintText: '理由（任意）',
-                border: OutlineInputBorder(),
-              ),
-              maxLines: 3,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('キャンセル'),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.pop(dialogContext);
-              final comment = commentController.text.trim();
-              _runVoidAction(
-                messenger,
-                () => (adapter as ReportSupport).reportPost(
-                  targetPost.id,
-                  targetPost.author.id,
-                  comment: comment.isNotEmpty ? comment : null,
-                ),
-                '通報しました',
-              );
-            },
-            child: const Text('通報'),
-          ),
-        ],
+    // 通報の宛先はアカウントで、投稿は証拠として添えるもの (#998)。
+    // Mastodon の `POST /api/v1/reports` は account_id が必須・status_ids が
+    // 任意、Misskey の `report-abuse` に至っては投稿を渡す口が無い。
+    // 「投稿だけが通報された」と読める文面にしない。
+    final comment = await showReportCommentDialog(
+      context,
+      message:
+          'この$postLabelを添えて '
+          '@${targetPost.author.username} をサーバー管理者に通報しますか？',
+    );
+    if (comment == null) return;
+
+    await _runVoidAction(
+      messenger,
+      () => (adapter as ReportSupport).reportPost(
+        targetPost.id,
+        targetPost.author.id,
+        comment: comment.isNotEmpty ? comment : null,
       ),
+      '通報しました',
     );
   }
 

--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -1482,12 +1482,18 @@ class _PostTileState extends ConsumerState<PostTile> {
     // 呼び出しが API 呼び出しより**前**にあるため、**操作が送信されないまま
     // 成功も失敗も出ずに消える**。
     final timeline = readVisibleTimelines(ref);
+    // ⚠ **ラベルも同じ理由で開く前に確定させる (#1009)。** ダイアログのボタンは
+    // シートの項目タップ (#996) より**さらに後**に押されるので、`ref.read` を
+    // `onPressed` に置くと dispose 済みで投げる。しかも投げるのは
+    // `deletePost` より前で、CAPSICUM-4R と同じ「送信されないまま成功も失敗も
+    // 出ない」形になる。
+    final postLabel = ref.read(postLabelProvider);
 
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text('${ref.read(postLabelProvider)}を削除'),
-        content: Text('この${ref.read(postLabelProvider)}を削除しますか？この操作は取り消せません。'),
+        title: Text('$postLabelを削除'),
+        content: Text('この$postLabelを削除しますか？この操作は取り消せません。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),
@@ -1501,11 +1507,16 @@ class _PostTileState extends ConsumerState<PostTile> {
                 timeline.removePost(targetPost.id);
                 if (mounted) setState(() => _deletedPostId = targetPost.id);
                 if (context.mounted) _popIfInThread(context);
-              }, '${ref.read(postLabelProvider)}を削除しました');
+              }, '$postLabelを削除しました');
             },
             child: Text(
               '削除',
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
+              // ⚠ **タイルの context から取らない (#659)。**ダイアログが再ビルド
+              // される（キーボード開閉・回転・テーマ変更）と、dispose 済みの
+              // Element を辿って落ちる。
+              style: TextStyle(
+                color: Theme.of(dialogContext).colorScheme.error,
+              ),
             ),
           ),
         ],
@@ -1518,6 +1529,9 @@ class _PostTileState extends ConsumerState<PostTile> {
     if (adapter is! ReportSupport) return;
     final messenger = ScaffoldMessenger.of(context);
     final commentController = TextEditingController();
+    // 理由は [_confirmDelete] の同名コメント (#1009)。この文面は builder の中に
+    // あるので、キーボードの開閉でダイアログが再ビルドされたときに投げる。
+    final postLabel = ref.read(postLabelProvider);
 
     showDialog(
       context: context,
@@ -1531,7 +1545,7 @@ class _PostTileState extends ConsumerState<PostTile> {
             // status_ids が任意、Misskey の `report-abuse` に至っては投稿を
             // 渡す口が無い。「投稿だけが通報された」と読める文面にしない。
             Text(
-              'この${ref.read(postLabelProvider)}を添えて '
+              'この$postLabelを添えて '
               '@${targetPost.author.username} をサーバー管理者に通報しますか？',
             ),
             const SizedBox(height: 12),
@@ -1576,16 +1590,15 @@ class _PostTileState extends ConsumerState<PostTile> {
     if (adapter == null) return;
     final messenger = ScaffoldMessenger.of(context);
     final router = GoRouter.of(context);
-    // 理由は [_confirmDelete] の同名コメント (#990)。
+    // 理由は [_confirmDelete] の同名コメント (#990 / #1009)。
     final timeline = readVisibleTimelines(ref);
+    final postLabel = ref.read(postLabelProvider);
 
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
         title: const Text('削除して再編集'),
-        content: Text(
-          '${ref.read(postLabelProvider)}を削除し、内容を再編集します。この操作は取り消せません。',
-        ),
+        content: Text('$postLabelを削除し、内容を再編集します。この操作は取り消せません。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),
@@ -1602,11 +1615,13 @@ class _PostTileState extends ConsumerState<PostTile> {
                 if (mounted) {
                   router.push('/compose', extra: {'redraft': targetPost});
                 }
-              }, '${ref.read(postLabelProvider)}を削除しました');
+              }, '$postLabelを削除しました');
             },
             child: Text(
               '削除して再編集',
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
+              style: TextStyle(
+                color: Theme.of(dialogContext).colorScheme.error,
+              ),
             ),
           ),
         ],
@@ -1829,6 +1844,9 @@ class _PostTileState extends ConsumerState<PostTile> {
     // `updateStatusTags` より**前**にあるので、投げると**タグづけが送信されない
     // まま無言で消える**。タグ管理は capsicum の根幹機能 (docs/CLAUDE.md)。
     final timeline = readVisibleTimelines(ref);
+    // ラベルも同じ理由で開く前に確定させる (#1009)。builder の中に置くと、
+    // 入力欄でキーボードが開いた再ビルドのときに dispose 済みで投げる。
+    final postLabel = ref.read(postLabelProvider);
 
     showModalBottomSheet(
       context: context,
@@ -1837,7 +1855,7 @@ class _PostTileState extends ConsumerState<PostTile> {
         initialTags: parsed.trailingTags,
         mulukhiya: mulukhiya,
         adapter: adapter!,
-        postLabel: ref.read(postLabelProvider),
+        postLabel: postLabel,
         onSubmit: (tags) async {
           try {
             final raw = await mulukhiya.updateStatusTags(

--- a/packages/capsicum/lib/src/ui/widget/report_comment_dialog.dart
+++ b/packages/capsicum/lib/src/ui/widget/report_comment_dialog.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+/// 通報の確認ダイアログ (#998)。理由を任意で添えられる。
+///
+/// 返すのは入力された理由（空文字もありうる）で、キャンセルは null。
+///
+/// ⚠ **controller はダイアログ自身が持つ (Codex P2 / PR #1013)。**
+/// `showDialog` の Future は**閉じるアニメーションの完了より前に**解決するため、
+/// 呼び出し側で `finally` 破棄すると、まだツリーに残っている `TextField` が
+/// 破棄済み controller に触れる。呼び出し側が持つ形にしていた 2 画面
+/// （投稿の通報 / プロフィールの通報）で、片方は早すぎる破棄、もう片方は破棄
+/// 漏れになっていたので、寿命ごとここへ寄せる。
+Future<String?> showReportCommentDialog(
+  BuildContext context, {
+  required String message,
+}) => showDialog<String>(
+  context: context,
+  builder: (_) => _ReportCommentDialog(message: message),
+);
+
+class _ReportCommentDialog extends StatefulWidget {
+  const _ReportCommentDialog({required this.message});
+
+  final String message;
+
+  @override
+  State<_ReportCommentDialog> createState() => _ReportCommentDialogState();
+}
+
+class _ReportCommentDialogState extends State<_ReportCommentDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('通報'),
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(widget.message),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _controller,
+          decoration: const InputDecoration(
+            hintText: '理由（任意）',
+            border: OutlineInputBorder(),
+          ),
+          maxLines: 3,
+        ),
+      ],
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: const Text('キャンセル'),
+      ),
+      TextButton(
+        onPressed: () => Navigator.pop(context, _controller.text.trim()),
+        child: const Text('通報'),
+      ),
+    ],
+  );
+}

--- a/packages/capsicum/test/compose_draft_save_order_guard_test.dart
+++ b/packages/capsicum/test/compose_draft_save_order_guard_test.dart
@@ -26,11 +26,7 @@ void main() {
     final start = lines.indexWhere(
       (l) => l.trimRight() == '  Future<void> _saveDraft() async {',
     );
-    expect(
-      start,
-      isNot(-1),
-      reason: '_saveDraft を見つけられない。シグネチャが変わったらこのテストも直す',
-    );
+    expect(start, isNot(-1), reason: '_saveDraft を見つけられない。シグネチャが変わったらこのテストも直す');
     final end = lines.indexWhere((l) => l == '  }', start + 1);
     expect(end, isNot(-1), reason: '_saveDraft の終端を見つけられない');
     // コメント行は落とす（この節は「await をまたぐ前に」と日本語で説明して

--- a/packages/capsicum/test/compose_draft_save_order_guard_test.dart
+++ b/packages/capsicum/test/compose_draft_save_order_guard_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 離脱時保存 (#966) が「await の後で controller を読む」形に戻っていないかの
+/// 検査 (Codex P2 / PR #1013)。
+///
+/// `_saveDraft` は投げっぱなしで呼ばれ、**呼んだ直後に State が dispose される**
+/// 経路（`PopScope` / ライフサイクル）が本命。await をまたいでから
+/// `_controller.text` を読むと破棄済み ChangeNotifier に触れて落ち、`mounted` で
+/// 抜ける形にすると**唯一の保存機会を捨てる**（書きかけがそのまま消える）。
+///
+/// 実際 PR #1013 では、取消の消去との直列化 (`await _draftClearing`) を保存値の
+/// 確定より前に置いてしまい、その後の `if (!mounted) return` で離脱時保存が
+/// 捨てられる形になっていた。順序そのものを固定する。
+///
+/// ソースを読む検査なのは、この経路が「dispose の直前に発火して、dispose の後も
+/// 走り続ける」タイミングでしか現れないため。widget test では
+/// `tester.pumpWidget` の破棄と保存の in-flight を狙って重ねられない。
+void main() {
+  test('_saveDraft は await より前に ComposeDraft を確定させる', () {
+    final lines = File(
+      'lib/src/ui/screen/compose_screen.dart',
+    ).readAsStringSync().split('\n');
+
+    final start = lines.indexWhere(
+      (l) => l.trimRight() == '  Future<void> _saveDraft() async {',
+    );
+    expect(
+      start,
+      isNot(-1),
+      reason: '_saveDraft を見つけられない。シグネチャが変わったらこのテストも直す',
+    );
+    final end = lines.indexWhere((l) => l == '  }', start + 1);
+    expect(end, isNot(-1), reason: '_saveDraft の終端を見つけられない');
+    // コメント行は落とす（この節は「await をまたぐ前に」と日本語で説明して
+    // いるので、素朴に検索するとコメントを拾う）。
+    final body = lines
+        .sublist(start, end + 1)
+        .where((l) => !l.trimLeft().startsWith('//'))
+        .toList(growable: false);
+
+    final snapshot = body.indexWhere((l) => l.contains('ComposeDraft('));
+    final firstAwait = body.indexWhere((l) => l.contains('await '));
+    expect(snapshot, isNot(-1), reason: '保存値の組み立てを拾えていない');
+    expect(firstAwait, isNot(-1), reason: 'await を拾えていない');
+    expect(
+      snapshot,
+      lessThan(firstAwait),
+      reason:
+          '_saveDraft が await の後で保存値を組んでいる。離脱時保存は dispose と'
+          '競合するので、controller を読むのは await より前でなければならない',
+    );
+  });
+}

--- a/packages/capsicum/test/compose_draft_store_test.dart
+++ b/packages/capsicum/test/compose_draft_store_test.dart
@@ -168,10 +168,7 @@ void main() {
       );
 
       expect(savedAt, fixedNow);
-      expect(
-        (await ComposeDraftStore().restore())!.text,
-        '取消のあとに書いた本文',
-      );
+      expect((await ComposeDraftStore().restore())!.text, '取消のあとに書いた本文');
     });
 
     test('#1008: 取消でも世代は進む（別画面の古い書き戻しは止めたまま）', () async {

--- a/packages/capsicum/test/compose_draft_store_test.dart
+++ b/packages/capsicum/test/compose_draft_store_test.dart
@@ -4,6 +4,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
+/// 世代印の書き込みだけを拒む prefs (Codex P2 / PR #1013)。スロットの世代が
+/// 据え置かれるのに、インスタンス側の印だけ進むと何が起きるかを見る。
+class _GenerationRejectingStore extends InMemorySharedPreferencesStore {
+  _GenerationRejectingStore() : super.empty();
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    if (key.contains(ComposeDraftStore.generationKey)) return false;
+    return super.setValue(valueType, key, value);
+  }
+}
+
 /// 書き込みを拒む prefs (#1011)。`SharedPreferences` の setter は失敗しても
 /// 投げず **false を返す**ので、この形でしか再現できない（端末が容量いっぱい・
 /// ストレージが壊れている・プラグイン側が落ちている、等）。
@@ -176,6 +188,45 @@ void main() {
       );
       // 破棄印は立てない（次の打鍵で再挑戦できる）。
       expect(store.discarded, isFalse);
+    });
+
+    /// Codex P2 (PR #1013): 世代印の永続化が拒まれた取消。
+    ///
+    /// ⚠ **「書けたときだけ印を進める」ではこの検査が落ちる。** `SharedPreferences`
+    /// は setter の結果に関わらずプロセス内のキャッシュを先に更新するので、拒否
+    /// されてもこのプロセスの `getInt` は新しい世代を返す。印を据え置くと以降の
+    /// [ComposeDraftStore.save] が毎回「世代ズレ」の no-op になり、**#1008 と
+    /// 同じ症状が別経路で戻る**（しかも no-op なので失敗としても出ない）。
+    /// 永続化の失敗は [ComposeDraftStore.clear] の戻り値で伝える。
+    test('REGRESSION: 世代を書けなかった取消でも、以降の保存は効く', () async {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesStorePlatform.instance = _GenerationRejectingStore();
+
+      final store = ComposeDraftStore();
+      await store.save(const ComposeDraft(text: '前回の書きかけ'), now: fixedNow);
+      await store.restore();
+
+      expect(
+        await store.clear(discard: false),
+        isFalse,
+        reason: '永続化できなかったことは戻り値で伝える',
+      );
+
+      expect(
+        await store.save(
+          const ComposeDraft(text: '取消のあとに書いた本文'),
+          now: fixedNow,
+        ),
+        fixedNow,
+      );
+      expect((await ComposeDraftStore().restore())!.text, '取消のあとに書いた本文');
+    });
+
+    test('書き込みが通る環境では clear は true を返す', () async {
+      final store = ComposeDraftStore();
+      await store.save(const ComposeDraft(text: '本文'), now: fixedNow);
+
+      expect(await store.clear(), isTrue);
     });
 
     /// #1008: 復元の「取消」だけは画面に留まったまま消す。破棄済みにすると、

--- a/packages/capsicum/test/compose_draft_store_test.dart
+++ b/packages/capsicum/test/compose_draft_store_test.dart
@@ -143,6 +143,58 @@ void main() {
 
       expect((await ComposeDraftStore().restore())!.text, '単発保存');
     });
+
+    /// #1008: 復元の「取消」だけは画面に留まったまま消す。破棄済みにすると、
+    /// `late final` のストアを持つその画面の自動保存が二度と効かず、取消の
+    /// あとに書いた本文が黙って失われる。
+    test('REGRESSION: clear(discard: false) のあとも、その画面の保存は効く', () async {
+      await ComposeDraftStore().save(
+        const ComposeDraft(text: '前回の書きかけ'),
+        now: fixedNow,
+      );
+
+      // 画面が開いて復元 → 「取消」。
+      final screen = ComposeDraftStore();
+      expect((await screen.restore())!.text, '前回の書きかけ');
+      await screen.clear(discard: false);
+
+      expect(screen.discarded, isFalse);
+      expect(await ComposeDraftStore().restore(), isNull);
+
+      // 取消のあとに書いた本文は、同じインスタンスから保存できる。
+      final savedAt = await screen.save(
+        const ComposeDraft(text: '取消のあとに書いた本文'),
+        now: fixedNow,
+      );
+
+      expect(savedAt, fixedNow);
+      expect(
+        (await ComposeDraftStore().restore())!.text,
+        '取消のあとに書いた本文',
+      );
+    });
+
+    test('#1008: 取消でも世代は進む（別画面の古い書き戻しは止めたまま）', () async {
+      await ComposeDraftStore().save(
+        const ComposeDraft(text: '共有の下書き'),
+        now: fixedNow,
+      );
+
+      final a = ComposeDraftStore();
+      final b = ComposeDraftStore();
+      expect((await a.restore())!.text, '共有の下書き');
+      expect((await b.restore())!.text, '共有の下書き');
+
+      // B が取消（画面は開いたまま）。
+      await b.clear(discard: false);
+
+      // A の離脱時保存は stale なので書き戻さない (#969)。
+      expect(
+        await a.save(const ComposeDraft(text: '共有の下書き'), now: fixedNow),
+        isNull,
+      );
+      expect(await ComposeDraftStore().restore(), isNull);
+    });
   });
 
   group('保存範囲の拡張 (#964)', () {

--- a/packages/capsicum/test/compose_draft_store_test.dart
+++ b/packages/capsicum/test/compose_draft_store_test.dart
@@ -2,6 +2,23 @@ import 'package:capsicum/src/service/compose_draft_store.dart';
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+/// 書き込みを拒む prefs (#1011)。`SharedPreferences` の setter は失敗しても
+/// 投げず **false を返す**ので、この形でしか再現できない（端末が容量いっぱい・
+/// ストレージが壊れている・プラグイン側が落ちている、等）。
+class _RejectingStore extends InMemorySharedPreferencesStore {
+  _RejectingStore() : super.empty();
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    // 世代印だけは通す（clear の副作用まで潰すと検査の意図がぼやける）。
+    if (key.contains(ComposeDraftStore.generationKey)) {
+      return super.setValue(valueType, key, value);
+    }
+    return false;
+  }
+}
 
 /// #966: 投稿フォームのローカル自動保存。保存範囲の拡張とアカウント別スロットは
 /// #964 で足した（[ComposeDraftStore.accountKey]）。
@@ -142,6 +159,23 @@ void main() {
       await store.save(const ComposeDraft(text: '単発保存'), now: fixedNow);
 
       expect((await ComposeDraftStore().restore())!.text, '単発保存');
+    });
+
+    /// #1011 (Codex P2 / PR #1013): 書き込みの拒否を、意図的な no-op と同じ
+    /// null で返してはいけない。区別できないと呼び出し側が失敗を観測も通知も
+    /// できず、**古い「自動保存 12:34」が表示に残ったまま本文を失う**。
+    test('REGRESSION: 書き込みを拒まれたら投げる（no-op の null と混ぜない）', () async {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesStorePlatform.instance = _RejectingStore();
+
+      final store = ComposeDraftStore();
+
+      await expectLater(
+        store.save(const ComposeDraft(text: '書けない本文'), now: fixedNow),
+        throwsA(isA<ComposeDraftSaveException>()),
+      );
+      // 破棄印は立てない（次の打鍵で再挑戦できる）。
+      expect(store.discarded, isFalse);
     });
 
     /// #1008: 復元の「取消」だけは画面に留まったまま消す。破棄済みにすると、

--- a/packages/capsicum/test/offline_retry_loop_transient_test.dart
+++ b/packages/capsicum/test/offline_retry_loop_transient_test.dart
@@ -122,6 +122,42 @@ void main() {
     });
   });
 
+  /// #1011: 起動判定 (#967) と probe 対象だけを絞っていたため、**ループの継続
+  /// 条件**が `offlineAccounts.isNotEmpty` のまま残っていた。到達不能で始まった
+  /// アカウントが未接続へ降格すると、probe 0 件の周回がプロセスの終わりまで
+  /// 回り続ける（`getSecrets` は呼ばれないので、上のテストでは見えない）。
+  test('REGRESSION: 未接続だけになったらループ自体が止まる', () {
+    fakeAsync((async) {
+      final storage = lockedStorage();
+      final container = ProviderContainer(
+        overrides: [accountStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+
+      container.read(accountManagerProvider.notifier).restoreSessions();
+      async.flushMicrotasks();
+      expect(async.pendingTimers, isNotEmpty, reason: '到達不能で始まったのでループは回っている');
+
+      // secret が消えた（= 未接続へ降格）。
+      when(() => storage.getSecrets(keyStr)).thenAnswer((_) async => null);
+      async.elapse(kOfflineRetryRampUp.first);
+      async.flushMicrotasks();
+      expect(
+        container
+            .read(accountManagerProvider)
+            .offlineAccounts
+            .single
+            .recoverableByRetry,
+        isFalse,
+      );
+
+      // 次の周回に入る前に畳まれている。残っていると 60 秒ごとの空回りが続く。
+      async.elapse(kOfflineRetrySteadyInterval * 2);
+      async.flushMicrotasks();
+      expect(async.pendingTimers, isEmpty);
+    });
+  });
+
   test('オフライン保持が 1 件も無ければループは起きない', () {
     fakeAsync((async) {
       final storage = _MockStorage();

--- a/packages/capsicum/test/post_tile_action_sheet_guard_test.dart
+++ b/packages/capsicum/test/post_tile_action_sheet_guard_test.dart
@@ -78,4 +78,59 @@ void main() {
           '$guards 箇所しかない。ガードの無い経路が残っている (#996)',
     );
   });
+
+  /// #1009: 母数はシートの項目だけではない。**そこから開くダイアログ / 二次
+  /// シートの中身**も同じ穴を持つ。項目タップの時点では生きていても、確認
+  /// ダイアログのボタンはさらに後に押されるし、builder は入力欄のキーボード
+  /// 開閉でも再び走る。その中で `ref` や タイルの `context` に触ると、
+  /// dispose 済みで StateError を投げ、**API 呼び出しの前に落ちる**＝ #996 と
+  /// まったく同じ「操作が無言で消える」形になる。
+  ///
+  /// 実際 #996 の修正では `timeline` だけ開く前に巻き上げ、`postLabelProvider`
+  /// が `onPressed` に残っていた。ガードの母数を「開いたあとに走るコード全部」
+  /// へ広げてここで固定する。
+  test('ダイアログ / シートの中で ref や タイルの context に触っていない', () {
+    final lines = File(
+      'lib/src/ui/widget/post_tile.dart',
+    ).readAsStringSync().split('\n');
+
+    final openings = <int>[];
+    final violations = <String>[];
+    for (var i = 0; i < lines.length; i++) {
+      if (!lines[i].contains('showDialog(') &&
+          !lines[i].contains('showModalBottomSheet(')) {
+        continue;
+      }
+      openings.add(i + 1);
+      // 開く呼び出しから、メソッド定義と同じインデントの閉じ括弧まで。
+      var end = i + 1;
+      while (end < lines.length && lines[end] != '  }') {
+        end++;
+      }
+      for (var j = i; j < end; j++) {
+        final line = lines[j];
+        if (line.contains('ref.read(') ||
+            line.contains('ref.watch(') ||
+            line.contains('Theme.of(context)')) {
+          violations.add('${j + 1}: ${line.trim()}');
+        }
+      }
+      i = end;
+    }
+
+    // 抽出が壊れて空になると検査が素通りするので、まず母数を確かめる。
+    expect(
+      openings.length,
+      greaterThanOrEqualTo(6),
+      reason: 'ダイアログ / シートを拾えていない。抽出が実装とずれた可能性がある',
+    );
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'ダイアログ / シートを開いたあとに走るコードで ref かタイルの context に'
+          '触っている。開く前に値を確定させ、Theme は dialogContext から取ること'
+          ' (#1009)',
+    );
+  });
 }

--- a/packages/capsicum/test/profile_menu_report_entry_test.dart
+++ b/packages/capsicum/test/profile_menu_report_entry_test.dart
@@ -39,7 +39,12 @@ void main() {
     );
   });
 
-  test('通報ダイアログの TextEditingController が dispose される', () {
+  /// controller の寿命は #998 から追っている検査。**持ち主が変わった**
+  /// (Codex P2 / PR #1013) ので、見るものも変える — 画面が持って `finally` で
+  /// 捨てる形は、`showDialog` の Future が閉じるアニメーションの完了より前に
+  /// 解決するせいで**破棄が早すぎる**（まだツリーに居る `TextField` が破棄済み
+  /// controller に触れる）。ダイアログ自身に持たせるのが正で、画面側は持たない。
+  test('通報ダイアログの controller を画面が持たない', () {
     final lines = source().split('\n');
     final start = lines.indexWhere(
       (l) => l.trimRight() == '  Future<void> _confirmAndReportUser() async {',
@@ -55,13 +60,18 @@ void main() {
 
     expect(
       body,
-      contains('TextEditingController()'),
-      reason: '抽出が実装とずれている。理由の入力欄が見当たらない',
+      contains('showReportCommentDialog('),
+      reason:
+          '共通の通報ダイアログを通していない。理由の入力欄と controller の'
+          '寿命はダイアログ側が持つ (#1013)',
     );
     expect(
       body,
-      contains('commentController.dispose()'),
-      reason: 'キャンセルで閉じたときに controller が漏れる',
+      isNot(contains('TextEditingController(')),
+      reason:
+          '画面が controller を持っている。閉じるアニメーションの途中で'
+          '破棄すると、まだツリーに残っている TextField が破棄済み controller に'
+          '触れる (#1013)',
     );
   });
 }

--- a/packages/capsicum/test/settings_backup_import_guard_test.dart
+++ b/packages/capsicum/test/settings_backup_import_guard_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #1010: バックアップの取り込み口が 2 つあることの検査。
+///
+/// 設定画面（ログイン後）とサーバー選択画面（ログイン前）の両方から取り込める。
+/// **反映処理だけを共通化して、その手前を割ったまま**にしていたため、ログイン前
+/// の経路には確認ダイアログも失敗の計装も無かった。`/server` は新しい端末専用の
+/// 画面ではなく、ドロワーの「アカウントを追加」と未接続アカウントの「接続し直す」
+/// からも開くので、**設定を持っている端末の設定が無確認で上書きされる**。
+///
+/// ソースを読む検査なのは、ログイン前の画面がファイル選択（OS のピッカー）から
+/// 始まるため。widget test では `openFile` の先へ進めず、確認ダイアログの有無を
+/// 押さえられない。
+void main() {
+  const entries = {
+    'ログイン後（設定画面）':
+        'lib/src/ui/screen/settings/settings_backup_screen.dart',
+    'ログイン前（サーバー選択画面）': 'lib/src/ui/screen/server_selection_screen.dart',
+  };
+
+  for (final entry in entries.entries) {
+    group(entry.key, () {
+      final source = File(entry.value).readAsStringSync();
+
+      test('取り込みの前に確認を挟む', () {
+        expect(
+          source,
+          contains('confirmSettingsBackupImport('),
+          reason:
+              '${entry.value} が確認を挟んでいない。上書きは元に戻せないので、'
+              '両方の入口で共通の確認を通すこと (#1010)',
+        );
+      });
+
+      test('取り込めなかったキーを Sentry へ残す', () {
+        expect(
+          source,
+          contains('reportSettingsBackupImportSkips('),
+          reason:
+              '${entry.value} が skip を観測していない。移行の主経路はログイン前'
+              'なので、片方だけだと分布が偏る (#968 / #1010)',
+        );
+      });
+
+      test('取り込みの失敗を観測する', () {
+        expect(
+          source,
+          contains('reportOpFailure('),
+          reason:
+              '${entry.value} が失敗を計装していない。新規のファイル I/O は'
+              '失敗率を見る約束になっている (#968)',
+        );
+      });
+
+      test('部分失敗の但し書きを画面に出す', () {
+        expect(
+          source,
+          contains('settingsBackupSkippedNote('),
+          reason:
+              '${entry.value} が但し書きを出していない。索引の保存に失敗すると'
+              '追加 0 件になるので、これが無いと部分失敗が無言になる (#1010)',
+        );
+      });
+    });
+  }
+}

--- a/packages/capsicum/test/settings_backup_import_guard_test.dart
+++ b/packages/capsicum/test/settings_backup_import_guard_test.dart
@@ -15,8 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// 押さえられない。
 void main() {
   const entries = {
-    'ログイン後（設定画面）':
-        'lib/src/ui/screen/settings/settings_backup_screen.dart',
+    'ログイン後（設定画面）': 'lib/src/ui/screen/settings/settings_backup_screen.dart',
     'ログイン前（サーバー選択画面）': 'lib/src/ui/screen/server_selection_screen.dart',
   };
 

--- a/packages/capsicum/test/settings_backup_test.dart
+++ b/packages/capsicum/test/settings_backup_test.dart
@@ -365,6 +365,28 @@ void _accountIndexTests() {
       );
     });
 
+    /// #1011: 索引側が非正規形のときの突き合わせ。ファイル内の重複（下のテスト）
+    /// は塞いでいたが、**既にこの端末の索引に入っている key** は生のまま比較して
+    /// いたので、`contains` が外れて同じアカウントが 2 行（トークンあり / 未接続）
+    /// に割れる。ホストを大文字混じりで打って作ったアカウントで踏む。
+    test('索引側が非正規形でも、同じアカウントは足さない', () async {
+      final prefs = await prefsWith({
+        accountListKey: '["mastodon://alice@Mstdn.Example"]',
+      });
+
+      final result = await applySettingsBackupYaml(
+        prefs,
+        yamlWithAccounts([alice]),
+      );
+
+      expect(result.addedAccountKeys, isEmpty);
+      expect(
+        prefs.getString(accountListKey),
+        '["mastodon://alice@Mstdn.Example"]',
+        reason: '索引そのものは書き換えない（secret_<key> は生の key で引く）',
+      );
+    });
+
     test('正規形と非正規形が両方あっても 1 件にまとめる', () async {
       final prefs = await prefsWith({});
 


### PR DESCRIPTION
v1.59 のリリース前レビュー（`docs/store-release-guide.md` §4.0 の 5 観点）の結果。赤 3 件と、この枠で一緒に直せる黄をまとめて消化する。残りは #1012 で v1.60 へ送った。

Closes #1008
Closes #1009
Closes #1010
Closes #1011

## 赤

- **#1008 復元の「取消」で自動保存が死ぬ** — `clear()` の破棄印を戻す経路が無く、取消を押した画面はそれ以降まったく保存されなかった。#964 の主目的がこの経路だけ反転していた
- **#1009 削除確認ダイアログの「削除」が無言で消える** — `onPressed` の `ref.read` が dispose 済みで投げ、しかも `deletePost` より前。#996 で塞いだつもりの CAPSICUM-4R と同じ形。通報ダイアログとリタグシートも同型（こちらはキーボード開閉の再ビルドで踏む）
- **#1010 ログイン前の取り込みに確認が無い** — `/server` はログイン済みでも開くので、設定を持っている端末が無確認で上書きされる

## 黄

- ALT 編集の書き戻し先がページ送りで別の添付にずれる / 失敗が無計装 / controller のリーク
- 未接続だけになるとオフライン再試行ループが永久に空回りする
- 索引側が非正規形だと同じアカウントが 2 行に割れる
- 下書き保存が書き込み失敗を見ずに「自動保存 hh:mm」と出す

## 検査の追加

- `post_tile_action_sheet_guard_test.dart` の母数を「シートの項目」から「シート / ダイアログを開いたあとに走るコード全部」へ広げた
- `settings_backup_import_guard_test.dart` を新設し、2 つある取り込み口が確認・計装・但し書きを通していることを固定した
- ループの空回りは `getSecrets` が呼ばれず既存テストでは見えないので、fakeAsync の保留タイマーで観測する（修正前で落ちることを確認済み）

`dart format` / `dart analyze --fatal-infos` / `flutter test`（945 件）とも緑。
