### PR TITLE
fix: 生の例外が Sentry へ流れる経路を塞ぎ、機械で守る (#975)

### DIFF
--- a/packages/capsicum/lib/main.dart
+++ b/packages/capsicum/lib/main.dart
@@ -31,7 +31,6 @@ import 'src/service/desktop_notification_dispatcher.dart';
 import 'src/service/launch_at_login_service.dart';
 import 'src/service/resident_mode_service.dart';
 import 'src/service/apns_service.dart';
-import 'src/util/exception_scrub.dart';
 import 'src/service/fcm_service.dart';
 import 'src/service/notification_init.dart';
 import 'src/service/notification_label_cache.dart';
@@ -43,6 +42,7 @@ import 'src/service/share_intent_service.dart';
 import 'src/service/timeline_cache.dart';
 import 'src/service/window_state_service.dart';
 import 'src/service/wns_service.dart';
+import 'src/util/exception_scrub.dart';
 import 'src/util/sentry_observability.dart';
 import 'src/util/sentry_tag_hash.dart';
 import 'src/util/shared_preferences_cache.dart';
@@ -94,6 +94,22 @@ void _logDev(String message) {
   if (!kReleaseMode) debugPrint(message);
 }
 
+/// [_logDev] の例外版。**捕捉した例外は必ずこちらへ流すこと** (#975)。
+///
+/// `_logDev` は release では no-op だが **profile では debugPrint に流れる**。
+/// sentry_flutter の `DebugPrintIntegration` は build mode で分岐せず登録される
+/// ので、DSN 付きビルドでは breadcrumb になる。breadcrumb の `message` は
+/// [_scrubBreadcrumb]（`data` しか見ない）を通らないため、生の例外を埋めると
+/// DioException の URL がそのまま Sentry に載る。
+void _logDevException(String context, Object error, [StackTrace? stackTrace]) {
+  final scrubbed = scrubException(error);
+  _logDev(
+    stackTrace == null
+        ? '$context: $scrubbed'
+        : '$context: $scrubbed\n$stackTrace',
+  );
+}
+
 /// [_logDev] の StackTrace 版。
 void _logDevStack(StackTrace stackTrace) {
   if (!kReleaseMode) debugPrintStack(stackTrace: stackTrace);
@@ -134,7 +150,7 @@ Future<void> main() async {
   try {
     await PushKeyStore.migrateAccessibilityIfNeeded();
   } catch (e, st) {
-    _logDev('PushKeyStore migration failed: $e\n$st');
+    _logDevException('PushKeyStore migration failed', e, st);
   }
 
   // アカウント secret / client credentials も v1.30 以前は旧 Keychain
@@ -146,7 +162,7 @@ Future<void> main() async {
   try {
     await AccountStorage().migrateAccessibilityIfNeeded();
   } catch (e, st) {
-    _logDev('AccountStorage migration failed: $e\n$st');
+    _logDevException('AccountStorage migration failed', e, st);
   }
 
   // 起動キャッシュ (#890) の保存先を Application Support からキャッシュ領域へ
@@ -199,7 +215,7 @@ Future<void> main() async {
     try {
       sentryNativeDbPath = await resolveSentryNativeDatabasePath();
     } catch (e, st) {
-      _logDev('resolveSentryNativeDatabasePath failed: $e\n$st');
+      _logDevException('resolveSentryNativeDatabasePath failed', e, st);
     }
     await SentryFlutter.init((options) {
       options.dsn = dsn;
@@ -455,7 +471,7 @@ void _startApp() {
   // Sentry が自前で設定済なので ??= で上書きを避ける。
   FlutterError.onError ??= FlutterError.presentError;
   PlatformDispatcher.instance.onError ??= (e, st) {
-    _logDev('Uncaught: $e\n$st');
+    _logDevException('Uncaught', e, st);
     return true;
   };
 
@@ -822,7 +838,7 @@ void _routeToChatThread(
     } catch (e, st) {
       // user 解決失敗 (削除済み・通信エラー等) は通知タブにフォールバック。
       Sentry.captureException(
-        e,
+        scrubException(e),
         stackTrace: st,
         withScope: (scope) {
           scope.setTag('notification.routing', 'chat.user_resolve_failed');
@@ -1156,9 +1172,9 @@ Future<void> _initFirebase() async {
     });
     _logDev('capsicum: push.onMessage listener registered');
   } catch (e, st) {
-    _logDev('capsicum: Firebase initialization failed: $e');
+    _logDevException('capsicum: Firebase initialization failed', e);
     Sentry.captureException(
-      e,
+      scrubException(e),
       stackTrace: st,
       withScope: (scope) {
         scope.setTag('service', 'firebase_init');

--- a/packages/capsicum/lib/src/platform/background_task/timer_background_task_scheduler.dart
+++ b/packages/capsicum/lib/src/platform/background_task/timer_background_task_scheduler.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../../util/exception_scrub.dart';
 import 'background_task_scheduler.dart';
 
 /// macOS / Linux / Windows 向け実装。Dart の [Timer.periodic] を使った
@@ -50,12 +51,14 @@ class TimerBackgroundTaskScheduler
       } catch (e, st) {
         // スケジューラは次回 interval まで待たせ、ここで例外を握って
         // タスクを止めない。観測層で taskId 単位にグループしておく。
-        debugPrint(
-          'capsicum: background_task: callback failed (taskId=$taskId): $e\n$st',
+        debugLogException(
+          'capsicum: background_task: callback failed (taskId=$taskId)',
+          e,
+          st,
         );
         try {
           await Sentry.captureException(
-            e,
+            scrubException(e),
             stackTrace: st,
             withScope: (scope) {
               scope.setTag('background_task.id', taskId);

--- a/packages/capsicum/lib/src/platform/notification_subsystem/flutter_local_notification_subsystem.dart
+++ b/packages/capsicum/lib/src/platform/notification_subsystem/flutter_local_notification_subsystem.dart
@@ -84,7 +84,7 @@ class FlutterLocalNotificationSubsystem implements NotificationSubsystem {
       // 失敗が UI を巻き込まないよう更に try で包む。
       try {
         await Sentry.captureException(
-          e,
+          scrubException(e),
           stackTrace: st,
           hint: Hint.withMap({'subsystem': 'notification'}),
         );

--- a/packages/capsicum/lib/src/provider/account_manager_provider.dart
+++ b/packages/capsicum/lib/src/provider/account_manager_provider.dart
@@ -21,9 +21,9 @@ import '../service/push_registration_service.dart';
 import '../service/server_metadata_cache.dart';
 import '../service/timeline_cache.dart';
 import '../service/wns_service.dart';
+import '../util/exception_scrub.dart';
 import '../util/login_error.dart';
 import '../util/sentry_tag_hash.dart';
-import '../util/exception_scrub.dart';
 
 /// State: list of accounts + currently selected account.
 class AccountManagerState {
@@ -150,9 +150,10 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
       try {
         await adapter.detectTimelineAvailability();
       } catch (e) {
-        debugPrint(
+        debugLogException(
           'capsicum: addAccount: detectTimelineAvailability failed for '
-          '${account.key.toStorageKey()}: $e',
+          '${account.key.toStorageKey()}',
+          e,
         );
       }
     }
@@ -729,9 +730,10 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
       // させる。auth 失効（401/403）や secret 系・不明は従来通り skip + 観測。
       final outcome = classifyRestoreFailure(e);
       if (outcome == RestoreOutcome.retriable) {
-        debugPrint(
+        debugLogException(
           'capsicum: restoreSessions: transient failure for $keyStr, '
-          'kept offline and will retry in background: $e',
+          'kept offline and will retry in background',
+          e,
         );
         return (account: null, outcome: RestoreOutcome.retriable);
       }
@@ -780,9 +782,10 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
     final userFuture = adapter.getMyself();
     final timelineFuture = adapter is MastodonAdapter
         ? adapter.detectTimelineAvailability().catchError((Object e) {
-            debugPrint(
+            debugLogException(
               'capsicum: restoreSessions: detectTimelineAvailability '
-              'failed for $keyStr: $e',
+              'failed for $keyStr',
+              e,
             );
           })
         : Future<void>.value();
@@ -1160,7 +1163,7 @@ class AccountManagerNotifier extends Notifier<AccountManagerState> {
         parsed = null;
       }
       Sentry.captureException(
-        e,
+        scrubException(e),
         stackTrace: st,
         withScope: (scope) {
           // null 経路 (`_reportNullSecretSkipOnce`) と区別するための経路タグ。

--- a/packages/capsicum/lib/src/provider/drive_provider.dart
+++ b/packages/capsicum/lib/src/provider/drive_provider.dart
@@ -2,6 +2,7 @@ import 'package:capsicum_core/capsicum_core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../util/exception_scrub.dart';
 import 'account_manager_provider.dart';
 import 'timeline_provider.dart' show loadMoreMaxRetries, loadMoreRetryDelay;
 
@@ -95,7 +96,7 @@ class DriveContentsNotifier
     } catch (e, st) {
       try {
         Sentry.captureException(
-          e,
+          scrubException(e),
           stackTrace: st,
           hint: Hint.withMap({'folderId': arg ?? 'root'}),
         );
@@ -240,7 +241,7 @@ class DriveContentsNotifier
         try {
           final failedMaxId = current.files.lastOrNull?.id;
           Sentry.captureException(
-            e,
+            scrubException(e),
             stackTrace: st,
             hint: Hint.withMap({
               'folderId': arg ?? 'root',

--- a/packages/capsicum/lib/src/provider/instance_provider.dart
+++ b/packages/capsicum/lib/src/provider/instance_provider.dart
@@ -22,7 +22,7 @@ final currentInstanceProvider = FutureProvider<Instance?>((ref) async {
     return await adapter.getInstance();
   } catch (e, st) {
     debugLogException('getInstance failed', e);
-    Sentry.captureException(e, stackTrace: st);
+    Sentry.captureException(scrubException(e), stackTrace: st);
     return null;
   }
 });

--- a/packages/capsicum/lib/src/provider/server_config_provider.dart
+++ b/packages/capsicum/lib/src/provider/server_config_provider.dart
@@ -239,7 +239,7 @@ final customEmojisProvider = FutureProvider<List<CustomEmoji>>((ref) async {
       // 化してしまう (#609 false positive)。AsyncError として伝播させて
       // consumer の `valueOrNull == null` 判定で警告抑制経路に揃える。
       debugLogException('getEmojis failed', e);
-      Sentry.captureException(e, stackTrace: st);
+      Sentry.captureException(scrubException(e), stackTrace: st);
       rethrow;
     }
   }

--- a/packages/capsicum/lib/src/provider/timeline_provider.dart
+++ b/packages/capsicum/lib/src/provider/timeline_provider.dart
@@ -1824,7 +1824,7 @@ class TimelineNotifier extends AutoDisposeAsyncNotifier<TimelineState> {
         try {
           final failedMaxId = current.posts.lastOrNull?.id;
           Sentry.captureException(
-            e,
+            scrubException(e),
             stackTrace: st,
             hint: Hint.withMap({
               'maxId': failedMaxId ?? 'null',

--- a/packages/capsicum/lib/src/service/account_storage.dart
+++ b/packages/capsicum/lib/src/service/account_storage.dart
@@ -116,8 +116,9 @@ class AccountStorage {
       // plugin register race が retry 後も解消しないケース。同じ race で
       // delete も失敗するため、ここでは観測のみ行い secret は残す。
       // 次回起動で再試行される。
-      debugPrint(
-        'capsicum: plugin register race persisted for $accountKey: $e',
+      debugLogException(
+        'capsicum: plugin register race persisted for $accountKey',
+        e,
       );
       _reportOnce('secret:$accountKey', e, st);
       // secret は消していないので transient。ログアウト扱いにしない (#959)。
@@ -129,8 +130,9 @@ class AccountStorage {
       // 画面ロック解除前にアプリが起動した場合などで観測される
       // (CAPSICUM-1M, #531)。
       if (_isKeychainTransient(e)) {
-        debugPrint(
-          'capsicum: keychain transient for $accountKey (code=${e.code}): $e',
+        debugLogException(
+          'capsicum: keychain transient for $accountKey (code=${e.code})',
+          e,
         );
         _reportOnce('secret:$accountKey:transient', e, st, code: e.code);
         // secret は残っている。解錠後の再試行で読めるので transient (#959)。
@@ -144,9 +146,10 @@ class AccountStorage {
       // が secret を上書きするので無害）。-25308 のような明示 transient コードが
       // 無い Android では _isKeychainTransient が拾えないため、ここで分岐する。
       if (Platform.isAndroid) {
-        debugPrint(
+        debugLogException(
           'capsicum: android keystore read error for $accountKey, '
-          'keeping secret (code=${e.code}): $e',
+          'keeping secret (code=${e.code})',
+          e,
         );
         _reportOnce('secret:$accountKey:android_keystore', e, st, code: e.code);
         // secret を消していないので transient 扱い（次回起動で再試行）(#959)。
@@ -160,8 +163,9 @@ class AccountStorage {
       // BadPaddingException etc. may bypass PlatformException wrapping
       // after app reinstall (encryption key regenerated). Android では上と同様、
       // 一過性の Keystore 失敗で破壊しないよう delete を見送る (#730 / #731)。
-      debugPrint(
-        'capsicum: unexpected error reading secrets for $accountKey: $e',
+      debugLogException(
+        'capsicum: unexpected error reading secrets for $accountKey',
+        e,
       );
       if (Platform.isAndroid) {
         _reportOnce('secret:$accountKey:android_keystore', e, st);
@@ -321,8 +325,9 @@ class AccountStorage {
     } on PlatformException catch (e, st) {
       // ロック中 (-25308) 等で readAll / write が失敗しても起動は止めない。
       // flag を立てないので次回起動で再試行される。
-      debugPrint(
-        'capsicum: account storage accessibility migration failed: $e',
+      debugLogException(
+        'capsicum: account storage accessibility migration failed',
+        e,
       );
       _reportOnce('accessibility_migration', e, st);
     }
@@ -422,8 +427,9 @@ class AccountStorage {
     try {
       await _storage.delete(key: key);
     } on MissingPluginException catch (e, st) {
-      debugPrint(
-        'capsicum: plugin register race on delete for $accountKey: $e',
+      debugLogException(
+        'capsicum: plugin register race on delete for $accountKey',
+        e,
       );
       _reportOnce('secret:$accountKey:delete', e, st);
     } on PlatformException catch (e, st) {
@@ -582,7 +588,7 @@ class AccountStorage {
     if (!_reportedErrors.add(key)) return;
     try {
       Sentry.captureException(
-        error,
+        scrubException(error),
         stackTrace: st,
         withScope: code != null
             ? (scope) => scope.setTag('secret.code', code)

--- a/packages/capsicum/lib/src/service/announcement_subscription_service.dart
+++ b/packages/capsicum/lib/src/service/announcement_subscription_service.dart
@@ -127,9 +127,10 @@ class AnnouncementSubscriptionService {
       await enable(account);
     } catch (e) {
       // enable 内で Sentry 報告済み。本筋は止めない。
-      debugPrint(
+      debugLogException(
         'capsicum: announcement_subscription: auto-enable skipped for '
-        '${account.key.host}: $e',
+        '${account.key.host}',
+        e,
       );
     }
   }
@@ -229,8 +230,9 @@ class AnnouncementSubscriptionService {
     String host, {
     required String phase,
   }) {
-    debugPrint(
-      'capsicum: announcement_subscription: $phase failed for $host: $e',
+    debugLogException(
+      'capsicum: announcement_subscription: $phase failed for $host',
+      e,
     );
     Sentry.captureException(
       scrubException(e),

--- a/packages/capsicum/lib/src/service/fcm_service.dart
+++ b/packages/capsicum/lib/src/service/fcm_service.dart
@@ -62,7 +62,7 @@ class FcmService {
     } catch (e, st) {
       debugLogException('capsicum: push.fcm: initialization failed', e);
       Sentry.captureException(
-        e,
+        scrubException(e),
         stackTrace: st,
         withScope: (scope) {
           scope.setTag('service', 'fcm_init');

--- a/packages/capsicum/lib/src/service/push_registration_service.dart
+++ b/packages/capsicum/lib/src/service/push_registration_service.dart
@@ -282,8 +282,10 @@ class PushRegistrationService {
       // 本筋は止めない (relay 障害で push 全体を失敗にする筋ではない)。
       await AnnouncementSubscriptionService.autoEnableIfDefault(account);
     } catch (e, st) {
-      debugPrint(
-        'capsicum: push.registration: failed for ${account.key.host}: $e\n$st',
+      debugLogException(
+        'capsicum: push.registration: failed for ${account.key.host}',
+        e,
+        st,
       );
       // NB: 登録フェーズの失敗では relay row を触らない。
       //
@@ -411,8 +413,9 @@ class PushRegistrationService {
           );
         }
       } catch (e, st) {
-        debugPrint(
-          'capsicum: push.registration: adapter unsubscribe failed: $e',
+        debugLogException(
+          'capsicum: push.registration: adapter unsubscribe failed',
+          e,
         );
         _reportUnregisterFailure(e, st, account.key.host, 'adapter');
       }
@@ -465,9 +468,10 @@ class PushRegistrationService {
         final id = await PushKeyStore.getRelayId(a.key.toStorageKey());
         if (id != null) ids.add(id);
       } catch (e) {
-        debugPrint(
+        debugLogException(
           'capsicum: push.registration: relay id read failed for '
-          '${a.key.toStorageKey()}: $e',
+          '${a.key.toStorageKey()}',
+          e,
         );
       }
     }

--- a/packages/capsicum/lib/src/service/resident_mode_service.dart
+++ b/packages/capsicum/lib/src/service/resident_mode_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:dbus/dbus.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:tray_manager/tray_manager.dart';
@@ -164,8 +163,9 @@ class ResidentModeService with WindowListener, TrayListener {
     try {
       await _residentChannel.invokeMethod<void>('setDockIconHidden', hidden);
     } catch (e) {
-      debugPrint(
-        'capsicum: resident_mode: setDockIconHidden($hidden) failed: $e',
+      debugLogException(
+        'capsicum: resident_mode: setDockIconHidden($hidden) failed',
+        e,
       );
     }
   }

--- a/packages/capsicum/lib/src/ui/screen/compose_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/compose_screen.dart
@@ -1651,7 +1651,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
     try {
       bytes = await original.readAsBytes();
     } catch (e, st) {
-      await Sentry.captureException(e, stackTrace: st);
+      await Sentry.captureException(scrubException(e), stackTrace: st);
       if (mounted) {
         ScaffoldMessenger.of(
           context,
@@ -1699,7 +1699,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
     try {
       bytes = await original.readAsBytes();
     } catch (e, st) {
-      await Sentry.captureException(e, stackTrace: st);
+      await Sentry.captureException(scrubException(e), stackTrace: st);
       if (mounted) {
         ScaffoldMessenger.of(
           context,
@@ -1755,7 +1755,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
       await out.writeAsBytes(bytes, flush: true);
       return XFile(path, mimeType: 'image/png', name: pngName);
     } catch (e, st) {
-      await Sentry.captureException(e, stackTrace: st);
+      await Sentry.captureException(scrubException(e), stackTrace: st);
       return null;
     }
   }
@@ -3294,7 +3294,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen>
         // 再投稿手段をユーザーに提示する (#393)。
         await Clipboard.setData(ClipboardData(text: _controller.text));
         await Sentry.captureException(
-          e,
+          scrubException(e),
           stackTrace: st,
           withScope: (scope) => scope.setTag('phase', 'redraft_resend_failed'),
         );

--- a/packages/capsicum/lib/src/ui/screen/image_crop_screen.dart
+++ b/packages/capsicum/lib/src/ui/screen/image_crop_screen.dart
@@ -6,6 +6,8 @@ import 'package:crop_your_image/crop_your_image.dart';
 import 'package:flutter/material.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../../util/exception_scrub.dart';
+
 /// 添付画像をトリミング・回転する全画面エディタ (#577 / #647 / #662)。
 ///
 /// crop_your_image は platform channel を持たない純 Flutter 実装のため、
@@ -63,7 +65,7 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
       if (!mounted) return;
       setState(() => _normalizedImage = data.buffer.asUint8List());
     } catch (e, st) {
-      await Sentry.captureException(e, stackTrace: st);
+      await Sentry.captureException(scrubException(e), stackTrace: st);
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
@@ -154,7 +156,7 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
       });
       _controller.image = bytes;
     } catch (e, st) {
-      await Sentry.captureException(e, stackTrace: st);
+      await Sentry.captureException(scrubException(e), stackTrace: st);
       if (!mounted) return;
       setState(() => _rotating = false);
       ScaffoldMessenger.of(

--- a/packages/capsicum/lib/src/ui/util/post_actions.dart
+++ b/packages/capsicum/lib/src/ui/util/post_actions.dart
@@ -235,12 +235,21 @@ class PostActionRunner {
     required String phase,
   }) {
     debugLogException('PostActionRunner.$label failed', e);
-    if (kDebugMode && e is DioException) {
+    // scrub 済みの表現は type / status / path までで、失敗の理由（Mastodon の
+    // `{"error": "..."}`）が落ちる。手元で原因を追うにはこれが要るので、
+    // Sentry が動いていないときに限って生の body を出す。
+    //
+    // ⚠ **`kDebugMode` だけでは足りない。**sentry_flutter の
+    // DebugPrintIntegration は build mode で分岐せず登録されるので、DSN を
+    // 渡した debug ビルドでは breadcrumb になる（debug に DSN を渡さないのは
+    // 運用の約束であって、仕組みではない）。`isEnabled` で仕組みの側に寄せる。
+    if (kDebugMode && !Sentry.isEnabled && e is DioException) {
+      // scrub-guard: allow — Sentry 無効時のみ。上のとおり経路が閉じている
       debugPrint('Response body: ${e.response?.data}');
     }
     unawaited(
       Sentry.captureException(
-        e,
+        scrubException(e),
         stackTrace: st,
         withScope: (scope) => scope.setTag('phase', phase),
       ),

--- a/packages/capsicum/lib/src/ui/util/visible_timeline.dart
+++ b/packages/capsicum/lib/src/ui/util/visible_timeline.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:capsicum_core/capsicum_core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../provider/channel_provider.dart';
@@ -10,6 +9,7 @@ import '../../provider/list_provider.dart';
 import '../../provider/tab_selection_provider.dart';
 import '../../provider/timeline_provider.dart';
 import '../../service/timeline_cache.dart';
+import '../../util/exception_scrub.dart';
 import '../widget/content_parser.dart';
 
 /// 投稿の削除・再投稿・差し替えを「いま画面に出ている TL」へ反映するための
@@ -195,7 +195,10 @@ VisibleTimelineMutator readVisibleTimelinesOrDetached(WidgetRef ref) {
   try {
     return readVisibleTimelines(ref);
   } on StateError catch (e) {
-    debugPrint('capsicum: visible timeline unavailable (widget disposed): $e');
+    debugLogException(
+      'capsicum: visible timeline unavailable (widget disposed)',
+      e,
+    );
     return VisibleTimelineMutator.detached;
   }
 }

--- a/packages/capsicum/lib/src/ui/widget/cross_account_boost.dart
+++ b/packages/capsicum/lib/src/ui/widget/cross_account_boost.dart
@@ -8,6 +8,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import '../../model/account.dart';
 import '../../provider/account_manager_provider.dart';
 import '../../provider/server_config_provider.dart';
+import '../../util/exception_scrub.dart';
 import '../util/post_action_error.dart';
 import 'emoji_text.dart';
 import 'server_badge.dart';
@@ -144,7 +145,7 @@ Future<void> _boostWithAccount(
     // 「別垢ブーストが通らない」という報告の裏取りができない。
     unawaited(
       Sentry.captureException(
-        e,
+        scrubException(e),
         stackTrace: st,
         withScope: (scope) => scope.setTag('phase', 'post_action'),
       ),

--- a/packages/capsicum/lib/src/ui/widget/post_tile.dart
+++ b/packages/capsicum/lib/src/ui/widget/post_tile.dart
@@ -1785,7 +1785,7 @@ class _PostTileState extends ConsumerState<PostTile> {
                   .catchError((Object e, StackTrace st) {
                     unawaited(
                       Sentry.captureException(
-                        e,
+                        scrubException(e),
                         stackTrace: st,
                         withScope: (scope) =>
                             scope.setTag('phase', 'post_action'),
@@ -1856,7 +1856,7 @@ class _PostTileState extends ConsumerState<PostTile> {
           } catch (e, st) {
             unawaited(
               Sentry.captureException(
-                e,
+                scrubException(e),
                 stackTrace: st,
                 withScope: (scope) => scope.setTag('phase', 'post_action'),
               ),

--- a/packages/capsicum/test/exception_scrub_guard_test.dart
+++ b/packages/capsicum/test/exception_scrub_guard_test.dart
@@ -1,0 +1,314 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #975: 例外を Sentry へ流す経路を機械で守る。
+///
+/// `exception_scrub.dart` の doc は「生の例外を直接埋める形をリポジトリから
+/// 無くす」と宣言しているが、#926 の置換は **1 行に収まっていた `debugPrint`
+/// だけ**に当たっていた。改行をまたぐ形と、`captureException` へ生の例外を
+/// 渡す形は残っていた。
+///
+/// ⚠⚠ **単一行の grep では 0 件に見える。**だから次も同じ取りこぼし方をする。
+/// この検査は**ファイル全体を読んで括弧を数える**ので、引数が何行に分かれて
+/// いても拾う。
+///
+/// ## なぜ優先度が高いか
+///
+/// release ビルドでは sentry_flutter が `debugPrint` を丸ごと breadcrumb 化
+/// する。breadcrumb の `message` は `main.dart` の `_scrubBreadcrumb`（`data`
+/// しか見ない）を通らないので、生の例外文字列がそのまま載る。さらに
+/// `captureException` の `exceptions[].value` は **breadcrumb と違って必ず
+/// 送られる**。
+///
+/// 今のところ実害が無いのは dio 5.9.x の
+/// `defaultDioExceptionReadableStringBuilder` が URI を含まないからで、
+/// **dio を上げた瞬間に無言で再発する**。
+void main() {
+  /// 検査対象。⚠ **capsicum パッケージだけでは足りない** — アダプタ側にも
+  /// 同じ形が入りうるので、テストを 1 箇所に置いたまま隣のパッケージも読む。
+  const roots = <String>[
+    'lib',
+    '../capsicum_core/lib',
+    '../capsicum_backends/lib',
+  ];
+
+  /// 生の例外を渡してよい例外的な場所。**増やすときは理由を書くこと。**
+  const allowedFiles = <String>{
+    // scrub の実装そのもの。ここで scrubException を呼んだら無限再帰。
+    'lib/src/util/exception_scrub.dart',
+  };
+
+  List<File> dartFiles() => [
+    for (final root in roots)
+      if (Directory(root).existsSync())
+        ...Directory(root)
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.dart'))
+            .where((f) => !f.path.endsWith('.g.dart'))
+            .where((f) => !f.path.endsWith('.freezed.dart')),
+  ];
+
+  /// [open]（`(` の位置）に対応する閉じ括弧の index。見つからなければ -1。
+  ///
+  /// 文字列リテラルの中の括弧は数えない。⚠ **ここを雑にすると、`'('` を含む
+  /// 文言で検査全体が静かに壊れる**（見逃しても誰も気づかない）。
+  int matchParen(String s, int open) {
+    var depth = 0;
+    String? quote;
+    for (var i = open; i < s.length; i++) {
+      final c = s[i];
+      if (quote != null) {
+        if (c == r'\') {
+          i++;
+        } else if (c == quote) {
+          quote = null;
+        }
+        continue;
+      }
+      if (c == "'" || c == '"') {
+        quote = c;
+        continue;
+      }
+      if (c == '(') depth++;
+      if (c == ')') {
+        depth--;
+        if (depth == 0) return i;
+      }
+    }
+    return -1;
+  }
+
+  /// 引数リストを top-level のカンマで割る。
+  List<String> splitArgs(String args) {
+    final out = <String>[];
+    var depth = 0;
+    var start = 0;
+    String? quote;
+    for (var i = 0; i < args.length; i++) {
+      final c = args[i];
+      if (quote != null) {
+        if (c == r'\') {
+          i++;
+        } else if (c == quote) {
+          quote = null;
+        }
+        continue;
+      }
+      if (c == "'" || c == '"') {
+        quote = c;
+        continue;
+      }
+      if (c == '(' || c == '[' || c == '{') depth++;
+      if (c == ')' || c == ']' || c == '}') depth--;
+      if (c == ',' && depth == 0) {
+        out.add(args.substring(start, i).trim());
+        start = i + 1;
+      }
+    }
+    final tail = args.substring(start).trim();
+    if (tail.isNotEmpty) out.add(tail);
+    return out;
+  }
+
+  /// 呼び出しごとに `(引数リスト, 呼び出しの開始 index)` を返す。
+  List<(String, int)> callsOf(String source, String name) {
+    final out = <(String, int)>[];
+    final pattern = RegExp('(?<![A-Za-z0-9_])$name\\s*\\(');
+    for (final m in pattern.allMatches(source)) {
+      final open = source.indexOf('(', m.start);
+      final close = matchParen(source, open);
+      if (close < 0) continue;
+      out.add((source.substring(open + 1, close), m.start));
+    }
+    return out;
+  }
+
+  /// 個別に見逃す指示。**直前の行に書く。**
+  ///
+  /// ファイル単位の allowlist より狭く、grep で全件を数えられる形にしてある。
+  /// ⚠ **理由を同じ行に書くこと**（`// $marker: <理由>`）。理由の無い抑止は
+  /// レビューで落とす。
+  const marker = 'scrub-guard: allow';
+
+  /// [start] の呼び出しに [marker] が付いているか。直前の非空行だけを見る
+  /// ので、離れた場所のコメントが効いてしまうことはない。
+  bool isMarked(String source, int start) {
+    final head = source.substring(0, start);
+    final lines = head.split('\n');
+    // 末尾は呼び出し自身の行頭（インデントのみ）。その手前へさかのぼる。
+    for (var i = lines.length - 2; i >= 0; i--) {
+      final line = lines[i].trim();
+      if (line.isEmpty) continue;
+      return line.startsWith('//') && line.contains(marker);
+    }
+    return false;
+  }
+
+  /// 捕捉した例外を素で埋めている補間を探す。
+  ///
+  /// ⚠ **`$entry` / `$expected` を拾わない**よう、識別子の切れ目まで見る。
+  ///
+  /// ⚠ **メンバーアクセスは中身で判断する。**`${e.type.name}`（dio の enum 名）
+  /// や `${e.code}`（PlatformException のコード）は素性が分かっていて安全な
+  /// ので通す。危ないのは**オブジェクトを丸ごと**（`$e` / `${e}`）と、上流の
+  /// 生データを引く経路（`.message` / `.data` / `.toString()` / `.uri` 等）。
+  ///
+  /// StackTrace は対象外。コード位置しか持たず、[debugLogException] 自身も
+  /// 素通しする前提で作ってある。
+  final interpolationStart = RegExp(
+    r'\$\{?(e|err|error|ex|exception)(?![A-Za-z0-9_])',
+  );
+  final unsafeMembers = RegExp(
+    r'\b(message|data|body|uri|path|toString|requestOptions)\b',
+  );
+
+  /// [args] の中の危ない補間を返す。
+  List<String> unsafeInterpolations(String args) {
+    final found = <String>[];
+    for (final m in interpolationStart.allMatches(args)) {
+      final after = args.substring(m.end);
+      if (!after.startsWith('.') && !after.startsWith('?.')) {
+        // `$e` / `${e}` — オブジェクトを丸ごと埋めている。
+        found.add(m.group(0)!);
+        continue;
+      }
+      // メンバーアクセス。補間の終端（`}` か、識別子・`.`・`?` の切れ目）まで見る。
+      final chainMatch = RegExp(r'^[A-Za-z0-9_.?\[\]]*').firstMatch(after)!;
+      final chain = chainMatch.group(0)!;
+      if (unsafeMembers.hasMatch(chain)) found.add('${m.group(0)}$chain');
+    }
+    return found;
+  }
+
+  String relativePath(File f) =>
+      f.path.replaceFirst('${Directory.current.path}/', '');
+
+  test('captureException には scrub 済みの例外だけを渡す', () {
+    final offenders = <String>[];
+    for (final file in dartFiles()) {
+      final path = relativePath(file);
+      if (allowedFiles.contains(path)) continue;
+      final source = file.readAsStringSync();
+      for (final (args, start) in callsOf(source, 'captureException')) {
+        final first = splitArgs(args).firstOrNull;
+        if (first == null || first.isEmpty) continue;
+        if (isMarked(source, start)) continue;
+        // scrub 済み / その場で作った合成エラー（`StateError('...')` 等）は可。
+        if (first.startsWith('scrubException(')) continue;
+        // 直前で `final scrubbed = scrubException(e);` と控えた変数も可。
+        // ⚠ **名前だけで信じる**ので、`scrubbed` を別の意味に使わないこと。
+        if (RegExp(r'^scrubbed[A-Za-z0-9_]*$').hasMatch(first)) continue;
+        if (RegExp(r'^[A-Z][A-Za-z0-9_]*\(').hasMatch(first)) continue;
+        offenders.add('$path: captureException($first, ...)');
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'exceptions[].value は breadcrumb と違って必ず送られる。'
+          'scrubException(e) を通すこと\n${offenders.join('\n')}',
+    );
+  });
+
+  /// breadcrumb になりうるログ経路。⚠ **`debugPrint` だけでは足りない** —
+  /// `main.dart` の `_logDev` のような**薄いラッパー**を経由すると、名前だけ
+  /// 見ている検査はすり抜ける（#975 の再発はここから起きた）。ラッパーが
+  /// 増えていないことは下の「ラッパーが増えていない」テストで担保する。
+  const breadcrumbSinks = <String>['debugPrint', '_logDev'];
+
+  test('ログ経路に捕捉した例外を埋めない（scrub 済みを渡す）', () {
+    final offenders = <String>[];
+    for (final file in dartFiles()) {
+      final path = relativePath(file);
+      if (allowedFiles.contains(path)) continue;
+      final source = file.readAsStringSync();
+      for (final sink in breadcrumbSinks) {
+        for (final (args, start) in callsOf(source, sink)) {
+          final unsafe = unsafeInterpolations(args);
+          if (unsafe.isEmpty) continue;
+          if (isMarked(source, start)) continue;
+          offenders.add('$path: $sink → ${unsafe.join(' / ')}');
+        }
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'sentry_flutter の DebugPrintIntegration は build mode で分岐せず'
+          '登録される。breadcrumb の message は _scrubBreadcrumb（data しか'
+          '見ない）を通らないので、debugLogException / _logDevException を'
+          '使うこと\n${offenders.join('\n')}',
+    );
+  });
+
+  /// [breadcrumbSinks] の網羅性を守る。**新しいラッパーが増えると、上の検査は
+  /// 何も言わずに素通りする**（#975 の取りこぼしの正体がこれ）。
+  ///
+  /// 判定は「`debugPrint` に**文字列リテラル以外**を渡しているか」。素の
+  /// `debugPrint('...')` は呼び出し側なので通し、`debugPrint(message)` の形＝
+  /// 受け取った値をそのまま流す関数＝ラッパーだけを拾う。
+  test('debugPrint のラッパーが増えていない', () {
+    /// 既知のラッパー。**増やすときは [breadcrumbSinks] にも足すこと。**
+    const known = <String>{
+      // scrubException を通してから流す、推奨の経路。
+      'lib/src/util/exception_scrub.dart',
+      // release で no-op にする `_logDev` / `_logDevException`。
+      'lib/main.dart',
+    };
+    final wrappers = <String>[];
+    for (final file in dartFiles()) {
+      final path = relativePath(file);
+      if (known.contains(path)) continue;
+      final source = file.readAsStringSync();
+      for (final (args, _) in callsOf(source, 'debugPrint')) {
+        final first = splitArgs(args).firstOrNull;
+        if (first == null || first.isEmpty) continue;
+        if (first.startsWith("'") || first.startsWith('"')) continue;
+        wrappers.add('$path: debugPrint($first)');
+      }
+    }
+    expect(
+      wrappers,
+      isEmpty,
+      reason:
+          'debugPrint を包む関数を足したら breadcrumbSinks にも追加すること。'
+          '足さないと、そのラッパー越しの生例外を検査が見逃す\n'
+          '${wrappers.join('\n')}',
+    );
+  });
+
+  /// 検査そのものが空振りしていないことを見る。**ここが 0 だと、上の 2 つは
+  /// 何も読まずに緑になる**（roots の相対パスがずれた等）。
+  test('検査が実際にソースを読んでいる', () {
+    final files = dartFiles();
+    expect(files.length, greaterThan(100), reason: '対象ファイルが少なすぎる');
+    final total = files.fold<int>(
+      0,
+      (n, f) => n + callsOf(f.readAsStringSync(), 'captureException').length,
+    );
+    expect(total, greaterThan(10), reason: 'captureException を 1 つも見つけられていない');
+  });
+
+  /// 括弧の対応付けが文字列リテラルに騙されないこと。ここが壊れると、上の
+  /// 検査は静かに見逃す側へ倒れる。
+  test('文字列リテラル中の括弧を数えない', () {
+    const source = "debugPrint('a) b', \$e);";
+    final calls = callsOf(source, 'debugPrint');
+    expect(calls, hasLength(1));
+    expect(calls.first.$1, "'a) b', \$e");
+  });
+
+  /// 見逃し指示が**直前の行だけ**に効くこと。効く範囲が広いと、無関係な
+  /// コメントで後続の違反まで黙る。
+  test('scrub-guard の marker は直前の行にだけ効く', () {
+    const marked = '// $marker: 理由\n  debugPrint(\$e);';
+    expect(isMarked(marked, marked.indexOf('debugPrint')), isTrue);
+
+    const distant = '// $marker: 理由\n  foo();\n  debugPrint(\$e);';
+    expect(isMarked(distant, distant.indexOf('debugPrint')), isFalse);
+  });
+}


### PR DESCRIPTION
Closes #975

`exception_scrub.dart` の doc は「生の例外を直接埋める形をリポジトリから無くす」と宣言していたが、#926 の置換は **1 行に収まっていた `debugPrint` だけ**に当たっていた。改行をまたぐ形、`captureException` へ生の例外を渡す形、`_logDev` のような薄いラッパー越しの形はすべて残っていた。

⚠ **単一行の grep では 0 件に見える。**だから同じ取りこぼし方を繰り返す。新設した検査はファイル全体を読んで括弧を数えるので、引数が何行に分かれていても拾う。capsicum だけでなく capsicum_core / capsicum_backends も読む。

## 塞いだ経路（38 箇所）

| 形 | 件数 | 置換先 |
| --- | ---: | --- |
| 生の `captureException(e, ...)` | 20 | `captureException(scrubException(e), ...)` |
| 改行をまたぐ `debugPrint('...: \$e')` | 18 | `debugLogException` / `_logDevException` |

`main.dart` は release で no-op にする `_logDev` (#512) を保つ必要があるため、`debugLogException` へ寄せず `_logDevException` を足してそちらへ通した。

## なぜ優先度が高いか

`captureException` の `exceptions[].value` は **breadcrumb と違って必ず送られる**。今のところ実害が出ていないのは dio 5.9.x の `defaultDioExceptionReadableStringBuilder` が URI を含まないからで、**dio を上げた瞬間に無言で再発する**。

## 検査を空振りさせないための自己テスト

この種の検査は「壊れても緑」になるのが最悪なので、検査自身を 3 本で固定した。

- **検査が実際にソースを読んでいる** — roots の相対パスがずれると本体の検査は何も読まずに緑になる
- **文字列リテラル中の括弧を数えない** — ここが雑だと `'('` を含む文言で検査全体が静かに壊れる
- **`debugPrint` のラッパーが増えていない** — 名前だけ見る検査はラッパーですり抜ける（**今回の取りこぼしの正体**）。`debugPrint` に文字列リテラル以外を渡す箇所＝ラッパーを列挙し、既知の 2 つ以外が出たら落とす

## 個別の見逃し指示

`// scrub-guard: allow — <理由>` を**直前の行**に書く。ファイル単位の allowlist より狭く、grep で全件を数えられる。効く範囲が直前の行だけであることもテストで固定した。

現状の利用は `post_actions.dart` の 1 件のみ。失敗理由（Mastodon の `{\"error\": ...}`）を手元で追うための生 body 出力で、`kDebugMode` に加えて `!Sentry.isEnabled` を条件にした。

⚠ **`kDebugMode` だけでは足りない。**sentry_flutter の `DebugPrintIntegration` は build mode で分岐せず登録される（`sentry_flutter.dart:256`、条件なし）ので、DSN を渡した debug ビルドでは breadcrumb になる。「debug に DSN を渡さない」(docs/dev-environment.md:82) は運用の約束であって仕組みではない。

## 直していないもの

`exception_scrub.dart` の doc は #975 の指示どおり据え置き。宣言に実態を合わせる側の変更なので、doc を書き換えると意味が逆になる。

## 確認

- `flutter analyze` — No issues found
- `flutter test` — 955 passed
- CI 常設化は追加設定なし。通常の `flutter test` で走る

🤖 Generated with [Claude Code](https://claude.com/claude-code)