### PR TITLE
fix: 下書きスロットの save / clear / restore を直列化する (#1028)

### DIFF
--- a/packages/capsicum/lib/src/service/compose_draft_store.dart
+++ b/packages/capsicum/lib/src/service/compose_draft_store.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:capsicum_core/capsicum_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -134,6 +136,39 @@ class ComposeDraftStore {
   int? _syncedGeneration;
   bool _superseded = false;
 
+  /// [save] / [clear] / [restore] を**このインスタンスの中で直列化する**
+  /// (Codex P2 / PR #1016)。
+  ///
+  /// ⚠⚠ **「割り込みを検出して後始末する」設計は破綻する。**それぞれが
+  /// `SharedPreferences` への往復を何度も挟むので、片方の書き込みがもう片方の
+  /// 削除の合間に着地しうる。v1.60 のリリース前レビューでこれを見つけ、
+  /// 「取消に追い越された save は自分の書き込みを消す」形で塞いだが、**その
+  /// 片づけ自体が次の破壊を作った**:
+  ///
+  /// 1. save#1 が走行中
+  /// 2. 取消 (`clear(discard: false)`) が世代を進めて完走
+  /// 3. ユーザーが書き直し、save#2 が**新しい本文を保存して完了**
+  /// 4. そこへ save#1 が追いつき、`_removeAll` が**save#2 のぶんごと消す**
+  ///
+  /// 画面は save#2 の「自動保存 hh:mm」を出したまま、再起動すると何も戻らない。
+  ///
+  /// 検出して直すのではなく**重ならないようにする**。順番に流せば、どの操作も
+  /// 「直前の操作が終わった状態」だけを見ればよくなり、上の分岐そのものが
+  /// 起きなくなる。
+  Future<void> _queue = Future<void>.value();
+
+  /// [body] を、このインスタンスの直前の操作が終わってから実行する。
+  Future<T> _serialized<T>(Future<T> Function() body) {
+    final previous = _queue;
+    final done = Completer<void>();
+    _queue = done.future;
+    // ⚠ 前の操作が投げても列を止めない（[save] は書き込み拒否で投げる）。
+    return previous
+        .catchError((_) {})
+        .then((_) => body())
+        .whenComplete(done.complete);
+  }
+
   /// [clear] を通ったあとかどうか。
   bool get discarded => _discarded;
 
@@ -179,7 +214,10 @@ class ComposeDraftStore {
   /// ⚠ **書き込みが拒まれたら [ComposeDraftSaveException] を投げる (#1011)。**
   /// null と混ぜると、呼び出し側が「意図した no-op」と区別できず、失敗が観測も
   /// 通知もされないまま**古い保存時刻が表示に残る**（Codex P2 / PR #1013）。
-  Future<DateTime?> save(ComposeDraft draft, {required DateTime now}) async {
+  Future<DateTime?> save(ComposeDraft draft, {required DateTime now}) =>
+      _serialized(() => _save(draft, now: now));
+
+  Future<DateTime?> _save(ComposeDraft draft, {required DateTime now}) async {
     if (_discarded) return null;
     final prefs = await SharedPreferences.getInstance();
     final current = prefs.getInt(_k(generationKey)) ?? 0;
@@ -222,16 +260,16 @@ class ComposeDraftStore {
     // 死ぬ**（#1008 が塞いだ「取消のあとの本文が黙って消える」が別経路で戻る）。
     final synced = _syncedGeneration;
     if (synced != null && synced > current) {
-      // ⚠⚠ **巻き戻さないだけでは足りない (Codex P2 / PR #1023)。**上の 8 回の
-      // 書き込みと `clear` の削除は**互いに割り込む**ので、こちらの値が削除の
-      // 後に着地しうる。印だけ守って抜けると:
+      // ⚠ **[_serialized] があるので、同一インスタンスの `clear` に追い越される
+      // ことはない。**ここへ来るのは `restore` が別インスタンスの進めた世代を
+      // 読み込んだ場合など。印を巻き戻さず、成功時刻も返さない。
       //
-      // - **取消したはずの本文がスロットに残り**、次の restore で戻ってくる
-      // - `now` を返すので、画面が消えたデータに対して「自動保存 12:34」を出す
-      //
-      // 書いたものを片づけて no-op として返す。`_allKeys` に世代印は含まれない
-      // ので、取消が進めた世代はそのまま残る（この画面の以降の保存は効く）。
-      await _removeAll(prefs, _k);
+      // ⚠⚠ **ここで書いたものを消してはいけない (Codex P2 / PR #1016)。**
+      // v1.60 のリリース前レビューでは「追い越された save は自分の書き込みを
+      // 片づける」形にしたが、その時点で**もっと新しい save が着地している
+      // 可能性**があり、スロットを一括削除するとそれごと消える。画面は新しい
+      // 保存の「自動保存 hh:mm」を出したまま、再起動すると何も戻らない。
+      // 掃除は世代を進めた当人（[clear]）の仕事。
       return null;
     }
     _syncedGeneration = current;
@@ -249,7 +287,9 @@ class ComposeDraftStore {
   ///
   /// アカウント別スロットが空で旧グローバルスロットに中身があれば、**このアカ
   /// ウントへ引き取る** (#964)。移行は 1 度きり（旧キーを消すため）。
-  Future<ComposeDraft?> restore() async {
+  Future<ComposeDraft?> restore() => _serialized(_restore);
+
+  Future<ComposeDraft?> _restore() async {
     final prefs = await SharedPreferences.getInstance();
     _syncedGeneration = prefs.getInt(_k(generationKey)) ?? 0;
 
@@ -258,7 +298,10 @@ class ComposeDraftStore {
       final legacy = _read(prefs, (k) => k);
       if (legacy != null) {
         await _removeAll(prefs, (k) => k);
-        await save(legacy, now: legacy.savedAt ?? DateTime.now());
+        // ⚠ **公開 [save] を呼ばない (Codex P2 / PR #1016)。**直列化を入れた
+        // ので、列の中から公開 API を呼ぶと**自分が持っている順番を待って
+        // デッドロックする**。内部呼び出しは private 側へ向ける。
+        await _save(legacy, now: legacy.savedAt ?? DateTime.now());
         draft = legacy;
       }
     }
@@ -313,7 +356,10 @@ class ComposeDraftStore {
   /// 起動で消したはずの本文が戻りうる**という意味 (Codex P2 / PR #1013)。
   /// 呼び出し側は観測に残す。投げないのは、投稿成功の直後にも通る経路で、
   /// ここで投げると**投稿は通っているのに失敗と伝える**ことになるため。
-  Future<bool> clear({bool discard = true}) async {
+  Future<bool> clear({bool discard = true}) =>
+      _serialized(() => _clear(discard: discard));
+
+  Future<bool> _clear({required bool discard}) async {
     if (discard) _discarded = true;
     final prefs = await SharedPreferences.getInstance();
     final next = (prefs.getInt(_k(generationKey)) ?? 0) + 1;

--- a/packages/capsicum/test/compose_draft_store_test.dart
+++ b/packages/capsicum/test/compose_draft_store_test.dart
@@ -292,29 +292,24 @@ void main() {
       await store.save(const ComposeDraft(text: '前回の書きかけ'), now: fixedNow);
       await store.restore();
 
-      // save を待たずに取消を差し込む（await しないので両者が同時に進む）。
+      // save を待たずに取消を差し込む（await しないので、直列化が無ければ
+      // 両者が同時に進む）。
       final saving = store.save(
         const ComposeDraft(text: '保存中の本文'),
         now: fixedNow,
       );
       final clearing = store.clear(discard: false);
-      final [savedAt, _] = await Future.wait([saving, clearing]);
+      await Future.wait([saving, clearing]);
 
       // ⚠⚠ **storage を見るのは、次の save で上書きする前 (Codex P2 / PR #1023)。**
       // 初版はここで先に「取消のあとに書いた本文」を保存してから中身を見ており、
       // **競合で残った本文が上書きされて観測できなかった**。印の巻き戻りだけを
       // 見て、データの復活を見逃す形になっていた。
-      //
-      // ⚠ **この 1 本目は現状 discriminate しない。**mock の割り込み順序では
-      // `clear` の削除が `save` の書き込みより後に着地するので、修正が無くても
-      // null になる。実機で順序が逆になったときのためのガードであって、証明では
-      // ない（実際に修正の有無を分けるのは下の `savedAt` のほう）。
       expect(
         await ComposeDraftStore().restore(),
         isNull,
         reason: '取消したのに、競合した save の本文がスロットへ残ってはいけない',
       );
-      expect(savedAt, isNull, reason: '消えたデータに対して「自動保存 hh:mm」を出す時刻を返してはいけない');
 
       // 印が巻き戻っていないので、取消のあとの入力はふつうに保存できる。
       expect(
@@ -327,6 +322,42 @@ void main() {
       );
       expect(store.superseded, isFalse);
       expect((await ComposeDraftStore().restore())!.text, '取消のあとに書いた本文');
+    });
+
+    /// v1.60 リリース PR の Codex P2: **追い越された save が、新しい save の
+    /// 本文を道連れにする**。
+    ///
+    /// 「割り込みを検出して自分の書き込みを片づける」形（#1023 の初版）だと、
+    /// 片づけの時点で**もっと新しい save が着地している**ことがある。スロットは
+    /// 1 枠なので一括削除がそれごと消し、画面は新しい保存の「自動保存 hh:mm」を
+    /// 出したまま、再起動すると何も戻らない。
+    ///
+    /// 検出して直すのではなく、[ComposeDraftStore] の中で直列化して**重ならない
+    /// ようにする**。
+    test('REGRESSION: 取消のあとに保存した本文を、古い save が消さない', () async {
+      final store = ComposeDraftStore();
+      await store.save(const ComposeDraft(text: '前回の書きかけ'), now: fixedNow);
+      await store.restore();
+
+      // 3 つとも await せずに積む。直列化が無いと 1 番目が 3 番目を消す。
+      final stale = store.save(
+        const ComposeDraft(text: '取消される前の本文'),
+        now: fixedNow,
+      );
+      final cancelling = store.clear(discard: false);
+      final fresh = store.save(
+        const ComposeDraft(text: '取消のあとに書き直した本文'),
+        now: fixedNow,
+      );
+      await Future.wait([stale, cancelling, fresh]);
+
+      expect(
+        (await ComposeDraftStore().restore())?.text,
+        '取消のあとに書き直した本文',
+        reason: '古い save の後始末が、新しい save の本文まで消してはいけない',
+      );
+      expect(await fresh, fixedNow, reason: '画面に出す時刻と中身が食い違ってはいけない');
+      expect(store.superseded, isFalse);
     });
 
     /// v1.60 リリース前レビュー: `superseded` は **latch しない**。


### PR DESCRIPTION
Closes #1028

リリース PR #1016 の Codex P2。**#1023 で入れた「追い越された save は自分の書き込みを片づける」が、次の破壊を作っていた。**

1. save#1 が走行中
2. 取消 (`clear(discard: false)`) が世代を進めて完走
3. ユーザーが書き直し、save#2 が新しい本文を保存して完了
4. そこへ save#1 が追いつき、`_removeAll` が **save#2 のぶんごと消す**

スロットは 1 枠なので一括削除が巻き添えにする。画面は save#2 の「自動保存 hh:mm」を出したまま、再起動すると何も戻らない。

## 検出して直すのをやめる

⚠ **割り込みを見つけて後始末する形は、v1.60 のレビューから 3 回連続で「塞いだつもりが別の窓を開ける」を繰り返した。** `SharedPreferences` への往復を何度も挟む以上、どの後始末も「その時点の状態」を仮定していて、それが崩れる。

インスタンスの中で `save` / `clear` / `restore` を直列化し、**重ならないようにする**。破壊的な `_removeAll` は外し、掃除は世代を進めた当人（`clear`）の仕事に戻した。

⚠ **列の中から公開 API を呼ぶとデッドロックする。** `_restore` の旧スロット移行が `save` を呼んでいて、自分が持っている順番を待って固まった（テストが 30 秒でタイムアウトして判明）。内部呼び出しは private 側へ向けた。

## テスト

Codex のシナリオを回帰テストにした。⚠ **修正を外すと `Actual: <null>` で落ちる**（新しい本文が消える）ことを確認済み。

- `flutter analyze` — No issues found
- `flutter test` — **1018 passed**
- `dart format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
